### PR TITLE
Add macOS support

### DIFF
--- a/README
+++ b/README
@@ -66,6 +66,30 @@ In addition to the usual options, configure understands the following:
        this value is actually supplied as "\\\\".
 
 
+macOS-specific instructions
+---------------------------
+
+To build plptools on macOS, you need to install the GNU readline library.
+Assuming Homebrew is your package manager:
+
+brew install readline
+
+If building from a git checkout, after running 'autoreconf -i', delete the
+'intl/VERSION' file so that it doesn't shadow a system include file when
+compiling.
+
+In order to enable readline and history support, you need to properly
+configure the build:
+
+LDFLAGS="-L$(brew --prefix readline)/lib" \
+CPPFLAGS="-I$(brew --prefix readline)/include" ./configure
+
+Then you can build and install the package:
+
+make
+make install
+
+
 Information for developers
 --------------------------
 

--- a/ncpd/Makefile.am
+++ b/ncpd/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS=-I$(top_srcdir)/lib
+AM_CPPFLAGS=-I$(top_srcdir)/lib -I$(top_srcdir)/intl
 AM_CFLAGS = $(THREADED_CFLAGS)
 AM_CXXFLAGS = $(THREADED_CXXFLAGS)
 

--- a/ncpd/mp_serial.c
+++ b/ncpd/mp_serial.c
@@ -31,6 +31,7 @@
 #include <string.h>		/* for bzero() */
 #include <termios.h>
 #if defined(linux) || defined(_IBMR2) || \
+	(defined(__APPLE__) && defined(__MACH__)) || \
 	defined(__NetBSD__) || defined(__FreeBSD__)
 #include <sys/ioctl.h>		/* for ioctl() */
 #endif
@@ -146,6 +147,7 @@ init_serial(const char *dev, int speed, int debug)
     ti.c_cflag = CS8 | HUPCL | CLOCAL | CREAD;
 #endif
 #if defined(sun) || defined(linux) || defined(__sgi) || \
+	(defined(__APPLE__) && defined(__MACH__)) || \
 	defined(__NetBSD__) || defined(__FreeBSD__)
     ti.c_cflag = CS8 | HUPCL | CLOCAL | CRTSCTS | CREAD;
     ti.c_iflag = IGNBRK | IGNPAR /*| IXON | IXOFF */;

--- a/plpprint/Makefile.am
+++ b/plpprint/Makefile.am
@@ -1,5 +1,5 @@
 sbin_PROGRAMS = plpprintd
-plpprintd_CPPFLAGS = -DPKGDATADIR="\"$(pkgdatadir)\"" -I$(top_srcdir)/lib
+plpprintd_CPPFLAGS = -DPKGDATADIR="\"$(pkgdatadir)\"" -I$(top_srcdir)/lib -I$(top_srcdir)/intl
 plpprintd_LDADD = $(LIB_PLP) $(INTLLIBS)
 plpprintd_SOURCES = plpprintd.cc
 

--- a/sisinstall/Makefile.am
+++ b/sisinstall/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS=-I$(top_srcdir)/lib
+AM_CPPFLAGS=-I$(top_srcdir)/lib -I$(top_srcdir)/intl
 
 bin_PROGRAMS = sisinstall
 sisinstall_LDADD = ../lib/libplp.la $(INTLLIBS)


### PR DESCRIPTION
I made a few changes to allow plptools to build and run on macOS.
`ncpd`, `plpftp`, `plpprint` and `sisinstall` work fine.
I didn’t test `plpfuse` as making MacFuse/OSXFuse work on recent macOS releases is a mess (kernel extensions being deprecated), but it can compile successfully.

These changes have been tested on macOS Ventura (13.6.1) on an Apple Silicon (M1) Mac, they should also work on Intel Macs as they’re not architecture-specific.
Building under Linux is still OK with these changes.