### PR TITLE
plpfuse: Point ENOATTR to ENODATA

### DIFF
--- a/plpfuse/fuse.c
+++ b/plpfuse/fuse.c
@@ -23,6 +23,9 @@
 #else
 #include <sys/xattr.h>
 #endif
+#ifndef ENOATTR
+#define ENOATTR ENODATA
+#endif
 #ifdef HAVE_ATTR_ATTRIBUTES_H
 #include <attr/attributes.h>
 #endif


### PR DESCRIPTION
`plpfuse` was failing to compile for me on Linux due to `ENOATTR` being missing from `sys/xattr.h`.

Based on https://github.com/janestreet/core/commit/069bacd90d923bd22fe45bebb3097ec96a4d8a50, I've added a `#define` for `ENOATTR` to point to `ENODATA` if it's missing.