### PR TITLE
plpftp: fix putclip adding unexpected newline

### DIFF
--- a/plpftp/ftp.cc
+++ b/plpftp/ftp.cc
@@ -245,10 +245,11 @@ get_upto(FILE *fp, const char *term, size_t *final_len)
         l = (char *)realloc(l, len + 1);
         assert(l);
     }
-    *s++ = '\0';
     
     if (final_len)
         *final_len = s - l;
+
+    *s++ = '\0';
     l = (char *)realloc(l, s - l);
     assert(l);
     return l;


### PR DESCRIPTION
The `putclip` command adds an unexpected newline to the content of the file sent to the Psion clipboard.

This is because the `get_upto` function returns a string length that includes the null terminator.
This terminator is then read as a regular character by the `ascii2PsiText` function, which converts it into Psion's new paragraph character (`0x06`).