### PR TITLE
feat: Add 'path test' functionality

### DIFF
--- a/lib/rfsv.h
+++ b/lib/rfsv.h
@@ -324,6 +324,27 @@ public:
     virtual Enum<errs> fgetattr(const char * const name, uint32_t &attr) = 0;
 
     /**
+     * Checks to see if the directory component of a path or file name exists
+     * and is valid. Returns `E_PSI_GEN_NONE` if is valid.
+     *
+     * Only paths up to the last trailing backslash are tested; trailing
+     * filenames are ignored. For example,
+     *
+     * - "C:\\" tests the validity of "C:\\"
+     * - "C:\\System" tests the validity of "C:\\"
+     * - "C:\\System\\" tests the validity of "C:\\System\\"
+     * - "D:\\Documents\\hello.txt" tests the validity of "D:\\Documents\\"
+     *
+     * This can be safely used to test for the existence of directories and
+     * drives on EPOC16 and EPOC32; check for `E_PSI_FILE_NXIST`,
+     * `E_PSI_FILE_DIR`, `E_PSI_FILE_DEVICE`, and `E_PSI_FILE_NOTREADY` to
+     * determine non-existence.
+     *
+     * @returns A Psion error code (One of enum @ref #errs ).
+     */
+    virtual Enum<errs> pathtest(const char * const name) = 0;
+
+    /**
     * Retrieves attributes, size and modification time of a file on the Psion.
     *
     * @param name The name of the file.

--- a/lib/rfsv16.cc
+++ b/lib/rfsv16.cc
@@ -692,6 +692,16 @@ copyOnPsion(const char *from, const char *to, void *ptr, cpCallback_t cb)
 }
 
 Enum<rfsv::errs> rfsv16::
+pathtest(const char * const path)
+{
+    string realName = convertSlash(path);
+    bufferStore a;
+    a.addStringT(realName.c_str());
+    sendCommand(SIBO_PATHTEST, a);
+    return getResponse(a);
+}
+
+Enum<rfsv::errs> rfsv16::
 fsetsize(uint32_t handle, uint32_t size)
 {
     bufferStore a;

--- a/lib/rfsv16.h
+++ b/lib/rfsv16.h
@@ -46,6 +46,7 @@ public:
     Enum<rfsv::errs> freplacefile(const uint32_t, const char * const, uint32_t &);
     Enum<rfsv::errs> fclose(const uint32_t);
     Enum<rfsv::errs> dir(const char * const, PlpDir &);
+    Enum<rfsv::errs> pathtest(const char * const);
     Enum<rfsv::errs> fgetmtime(const char * const, PsiTime &);
     Enum<rfsv::errs> fsetmtime(const char * const, const PsiTime);
     Enum<rfsv::errs> fgetattr(const char * const, uint32_t &);

--- a/lib/rfsv32.cc
+++ b/lib/rfsv32.cc
@@ -613,6 +613,19 @@ copyOnPsion(const char *from, const char *to, void *ptr, cpCallback_t cb)
 }
 
 Enum<rfsv::errs> rfsv32::
+pathtest(const char * const name)
+{
+    bufferStore a;
+    uint32_t r;
+    string n = convertSlash(name);
+    a.addWord(n.size());
+    a.addString(n.c_str());
+    if (!sendCommand(PATH_TEST, a))
+        return E_PSI_FILE_DISC;
+    return getResponse(a);
+}
+
+Enum<rfsv::errs> rfsv32::
 fsetsize(uint32_t handle, uint32_t size)
 {
     bufferStore a;

--- a/lib/rfsv32.h
+++ b/lib/rfsv32.h
@@ -48,6 +48,7 @@ public:
     Enum<rfsv::errs> copyFromPsion(const char *from, int fd, cpCallback_t cb);
     Enum<rfsv::errs> copyToPsion(const char * const, const char * const, void *, cpCallback_t);
     Enum<rfsv::errs> copyOnPsion(const char * const, const char * const, void *, cpCallback_t);
+    Enum<rfsv::errs> pathtest(const char * const);
     Enum<rfsv::errs> mkdir(const char * const);
     Enum<rfsv::errs> rmdir(const char * const);
     Enum<rfsv::errs> remove(const char * const);


### PR DESCRIPTION
Both the EPOC16 and EPOC32 remote file servers support path test functionality—`RFSV16_PATHTEST` (`0x22`)  and `RFSV32_PATH_TEST` (`0x2b`) respectively—but this has never been implemented or used internally in plptools. This change introduces a new `rfsv::pathtest` API and provides implementations in `rfsv16` and `rfsv32`.

Psion's implementation of this test is quite counter-intuitive (see the documentation in the header), but it's very helpful when providing a lightweight higher-level 'exists' API when combined with `fgetattr`.

While not strictly necessary for plptools in its current implementation, Reconnect relies on this functionality when using plptools as a client library and it makes sense to ensure plptools can provide as complete a protocol implementation as possible. (Ultimately, I hope we can formalize a plptools client API.)

This has been manually tested on EPOC16 and EPOC32 and behaviour matches that documented in in `rfsv.h`.