### PR TITLE
fix: ambiguous initialization on 32-bit platforms with 64-bit time_t …

### DIFF
--- a/lib/plpdirent.cc
+++ b/lib/plpdirent.cc
@@ -40,7 +40,7 @@ operator[](int idx) {
 }
 
 PlpDirent::PlpDirent()
-    : size(0), attr(0), name(""), time(0L), attrstr("") {
+    : size(0), attr(0), name(""), time(time_t(0)), attrstr("") {
 }
 
 PlpDirent::PlpDirent(const PlpDirent &e) {


### PR DESCRIPTION
…(armel, armhf)

Original Author: Andreas Beckmann <anbe@debian.org>