### PR TITLE
chore: Remove `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,0 @@
-root = true
-
-[*]
-charset = utf-8
-indent_style = space
-indent_size = 8
-trim_trailing_whitespace = true
-insert_final_newline = true


### PR DESCRIPTION
Unfortunately `.editorconfig` can't actually achieve what we want: while an `indent_size` of 8 does make the tabs display correctly, it causes issues when writing new code, as editors try to insert 8-space indents for each indent level. We're better off removing this and manually setting the tab size to 8-spaces in our editors.