### PR TITLE
fix: Ensure `fgeteattr` returns the correct filename on EPOC16

### DIFF
--- a/lib/rfsv16.cc
+++ b/lib/rfsv16.cc
@@ -26,6 +26,7 @@
 #include "ppsocket.h"
 #include "bufferarray.h"
 
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 


### PR DESCRIPTION
This change ensures we return an uppercased filename from `fgeteattr` when connected to EPOC16 devices, irrespective of the input path. This means the directory entry returned will match that created by a directory listing as EPOC16 will always return uppercased paths.