### PR TITLE
fix: Read the full owner information on EPOC16

### DIFF
--- a/lib/rpcs.cc
+++ b/lib/rpcs.cc
@@ -368,35 +368,6 @@ getUniqueID(const char *device, long &id)
 }
 
 Enum<rfsv::errs> rpcs::
-getOwnerInfo(bufferArray &owner)
-{
-    Enum<rfsv::errs> res;
-    bufferStore a;
-
-    if (!sendCommand(GET_OWNERINFO, a))
-        return rfsv::E_PSI_FILE_DISC;
-    if ((res = (enum rfsv::errs)getResponse(a, true)) != rfsv::E_PSI_GEN_NONE)
-        return res;
-    a.addByte(0);
-    string s = a.getString(0);
-    owner.clear();
-    int p = 0;
-    int l;
-    while ((l = s.find('\006', p)) != s.npos) {
-        bufferStore b;
-        b.addStringT(s.substr(p, l - p).c_str());
-        owner += b;
-        p = l + 1;
-    }
-    if (s.substr(p).length()) {
-        bufferStore b;
-        b.addStringT(s.substr(p).c_str());
-        owner += b;
-    }
-    return res;
-}
-
-Enum<rfsv::errs> rpcs::
 getMachineType(Enum<machs> &type)
 {
     Enum<rfsv::errs> res;

--- a/lib/rpcs.h
+++ b/lib/rpcs.h
@@ -269,7 +269,7 @@ public:
     *
     * @returns A psion error code. 0 = Ok.
     */
-    Enum<rfsv::errs> getOwnerInfo(bufferArray &owner);
+    virtual Enum<rfsv::errs> getOwnerInfo(bufferArray &owner) = 0;
 
     /**
     * Retrieves the type of machine on the remote side

--- a/lib/rpcs16.cc
+++ b/lib/rpcs16.cc
@@ -51,3 +51,31 @@ getCmdLine(const char *process, string &ret)
         ret = a.getString(0);
     return res;
 }
+
+Enum<rfsv::errs> rpcs16::
+getOwnerInfo(bufferArray &owner)
+{
+    Enum<rfsv::errs> res;
+    bufferStore a;
+
+    if (!sendCommand(GET_OWNERINFO, a)) {
+        return rfsv::E_PSI_FILE_DISC;
+    }
+    if ((res = (enum rfsv::errs)getResponse(a, true)) != rfsv::E_PSI_GEN_NONE) {
+        return res;
+    }
+
+    // Ensure the resulting buffer is null terminated.
+    a.addByte(0);
+
+    // It looks like the EPOC16 implementation returns a null-padded buffer with strings at fixed (52-character)
+    // offsets, so we read these into four separate strings and append them to our resulting array.
+    owner.clear();
+    for (int i = 0; i < 4; i++) {
+        bufferStore b;
+        b.addString(a.getString(52 * i));
+        owner += b;
+    }
+
+    return rfsv::E_PSI_GEN_NONE;
+}

--- a/lib/rpcs16.h
+++ b/lib/rpcs16.h
@@ -39,6 +39,8 @@ class rpcs16 : public rpcs {
 
  public:
     Enum<rfsv::errs> getCmdLine(const char *, std::string &);
+    Enum<rfsv::errs> getOwnerInfo(bufferArray &owner);
+
 
  private:
     rpcs16(ppsocket *);

--- a/lib/rpcs32.cc
+++ b/lib/rpcs32.cc
@@ -126,6 +126,35 @@ getMachineInfo(machineInfo &mi)
 }
 
 Enum<rfsv::errs> rpcs32::
+getOwnerInfo(bufferArray &owner)
+{
+    Enum<rfsv::errs> res;
+    bufferStore a;
+
+    if (!sendCommand(GET_OWNERINFO, a))
+        return rfsv::E_PSI_FILE_DISC;
+    if ((res = (enum rfsv::errs)getResponse(a, true)) != rfsv::E_PSI_GEN_NONE)
+        return res;
+    a.addByte(0);
+    string s = a.getString(0);
+    owner.clear();
+    int p = 0;
+    int l;
+    while ((l = s.find('\006', p)) != s.npos) {
+        bufferStore b;
+        b.addStringT(s.substr(p, l - p).c_str());
+        owner += b;
+        p = l + 1;
+    }
+    if (s.substr(p).length()) {
+        bufferStore b;
+        b.addStringT(s.substr(p).c_str());
+        owner += b;
+    }
+    return res;
+}
+
+Enum<rfsv::errs> rpcs32::
 regOpenIter(uint32_t uid, char *match, uint16_t &handle)
 {
     bufferStore a;

--- a/lib/rpcs32.h
+++ b/lib/rpcs32.h
@@ -39,6 +39,7 @@ class rpcs32 : public rpcs {
  public:
     Enum<rfsv::errs> getCmdLine(const char *, std::string &);
     Enum<rfsv::errs> getMachineInfo(machineInfo &);
+    Enum<rfsv::errs> getOwnerInfo(bufferArray &owner);
     Enum<rfsv::errs> configRead(uint32_t, bufferStore &);
     Enum<rfsv::errs> configWrite(bufferStore);
     Enum<rfsv::errs> closeHandle(uint16_t);


### PR DESCRIPTION
The EPOC16 and EPOC32 RPCS owner info implementations appear to be quite different and the common (EPOC32-friendly) implementation appears wasn’t working correctly on EPOC16, returning only the first line of text.

This change introduces platform-specific implementations, with a new EPOC16 implementation. EPOC16 seems to give us a null-padded buffer with four 4 lines of text at fixed offsets. This matches with the UI on my 3mx which has line-length limits, so the implementation simply always reads 4 strings at these fixed offsets.

This has been tested with a 3mx and an emulated 3.