### PR TITLE
refactor: Move actual ncp session into a separate method

### DIFF
--- a/ncpd/main.cc
+++ b/ncpd/main.cc
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 1999 Philip Proudman <philip.proudman@btinternet.com>
  *  Copyright (C) 1999-2001 Fritz Elfert <felfert@to.com>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This change moves the ncp session creation, and link and tcp threads orchestration into a new `run_ncp_session` method. This is a small part of a wider shuffle to move the actual work of ncpd out of `main.cc` and into a new source file and remove the reliance on global state. This is intended to make it easier to reuse this code in projects like Reconnect and prepare the way for a multi-device resident daemon in plptools.

I'm trying to keep the changes small to make it easier for us to reason about each step of the process.