### PR TITLE
fix: ncpd doesn’t respond to Ctrl+C

### DIFF
--- a/lib/iowatch.cc
+++ b/lib/iowatch.cc
@@ -58,7 +58,7 @@ void IOWatch::remIO(const int fd) {
     }
 }
 
-bool IOWatch::watch(const long secs, const long usecs, const int cancellationFd) {
+bool IOWatch::watch(const long secs, const long usecs) {
     int maxfd = 0;
     fd_set iop;
     FD_ZERO(&iop);
@@ -66,10 +66,6 @@ bool IOWatch::watch(const long secs, const long usecs, const int cancellationFd)
         FD_SET(io[i], &iop);
         if (io[i] > maxfd)
             maxfd = io[i];
-    }
-    FD_SET(cancellationFd, &iop);
-    if (cancellationFd > maxfd) {
-        maxfd = cancellationFd;
     }
     struct timeval t;
     t.tv_usec = usecs;

--- a/lib/iowatch.h
+++ b/lib/iowatch.h
@@ -66,7 +66,7 @@ public:
     *
     * @return true, if any of the descriptors is readable; false if the underlying select returned an error or the timeout expired.
     */
-    bool watch(const long secs, const long usecs, const int cancellationFd);
+    bool watch(const long secs, const long usecs);
 
 private:
     int num;

--- a/ncpd/ncp_session.cc
+++ b/ncpd/ncp_session.cc
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "ncp_session.h"
 
+#include <cassert>
 #include <cstring>
 #include <iostream>
 
@@ -36,13 +37,13 @@ static void *linkThread(void *arg) {
     NCPSession *session = (NCPSession *)arg;
     while (!session->isCancelled()) {
         // psion
-        session->iow.watch(1, 0, session->cancellationPipe[0]);
+        session->iow.watch(1, 0);
         if (session->ncp->hasFailed()) {
             if (session->autoexit) {
                 session->cancel();
                 break;
             }
-            session->iow.watch(5, 0, session->cancellationPipe[0]);
+            session->iow.watch(5, 0);
             if (session->isCancelled()) {
                 break;
             }
@@ -57,7 +58,7 @@ static void *linkThread(void *arg) {
 void *pollSocketConnections(void *arg) {
     NCPSession *session = (NCPSession *)arg;
     while (!session->isCancelled()) {
-        session->iow.watch(0, 10000, session->cancellationPipe[0]);
+        session->iow.watch(0, 10000);
         for (int i = 0; i < session->numScp; i++) {
             session->scp[i]->socketPoll();
             if (session->scp[i]->terminate()) {
@@ -79,7 +80,7 @@ void checkForNewSocketConnection(NCPSession *session) {
     // This watch returns false in the case of a time out or cancellation due to a signal, and true in the case of
     // cancellation or one of the file descriptors becoming readable. In the cause a timeout or interrupt, we return
     // flow of control to our calling code.
-    if (!session->acceptIOW.watch(5, 0, session->cancellationPipe[0]) || session->isCancelled()) {
+    if (!session->acceptIOW.watch(5, 0) || session->isCancelled()) {
         return;
     }
     ppsocket *next = session->skt.accept(&peer, &session->iow);
@@ -155,11 +156,14 @@ NCPSession::~NCPSession() {
 }
 
 int NCPSession::start() {
+    assert(threadId == 0);
     int result = pipe(cancellationPipe);
     if (result != 0) {
         return result;
     }
-    return pthread_create(&threadId_, NULL, runNCPSession, this);
+    iow.addIO(cancellationPipe[0]);
+    acceptIOW.addIO(cancellationPipe[0]);
+    return pthread_create(&threadId, NULL, runNCPSession, this);
 }
 
 void NCPSession::cancel() {
@@ -180,5 +184,5 @@ bool NCPSession::isCancelled() {
 }
 
 void NCPSession::wait() {
-    pthread_join(threadId_, 0);
+    pthread_join(threadId, 0);
 }

--- a/ncpd/ncp_session.h
+++ b/ncpd/ncp_session.h
@@ -88,7 +88,7 @@ public:
     unsigned short nverbose;
 
     // State.
-    pthread_t threadId_ = 0;
+    pthread_t threadId = 0;
     NCP *ncp = nullptr;
     IOWatch iow;
     IOWatch acceptIOW;


### PR DESCRIPTION
This change addresses a gnarly regression in `IOWatch` where the result of the internal `select` call was incorrectly being coerced to a bool and then compared to `<= 0` to see if IOWatch had exited as the result of an error. Since `(bool)(-1)` is `true`, and `true > 0`, this means we miss error cases. The specific error scenario we were missing here is the `SIGINT` from Ctrl+C which will occur before the cancellation file descriptor has been written to, so there's a race against the `isCancelled` check and we were sometimes dropping through to the blocking accept, even though there was nothing to accept.

This also includes a drive-by fix to revert the messy addition of and explicit `cancellationFd` parameter to `IOWatch::watch`—instead the cancellation file descriptor is added to both of `NCPSession`'s `IOWatch` instances during startup.