### PR TITLE
docs: Include private and non-documented members in docs

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -548,13 +548,13 @@ TIMESTAMP              = NO
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
 # methods of a class will be included in the documentation.


### PR DESCRIPTION
This change enables private member documentation, and ensures non-documented members are included in the Doxygen documentation. It has the effect of ensuring complete collaboration diagrams are generated and that nothing is hidden from the docs.