### PR TITLE
refactor: Hoist EPOC32-awareness into `Link`

### DIFF
--- a/ncpd/datalink.cc
+++ b/ncpd/datalink.cc
@@ -268,15 +268,11 @@ void DataLink::internalReset() {
     }
 }
 
-void DataLink::setEpoc(bool _epoc) {
-    isEPOC = _epoc;
-}
-
 int DataLink:: getSpeed() {
     return baudRate_;
 }
 
-void DataLink::send(bufferStore &b) {
+void DataLink::send(bufferStore &b, bool isEPOC) {
     opByte(0x16);
     opByte(0x10);
     opByte(0x02);

--- a/ncpd/datalink.h
+++ b/ncpd/datalink.h
@@ -44,9 +44,8 @@ public:
     /**
      * Send a buffer out to serial line
      */
-    void send(bufferStore &b);
+    void send(bufferStore &b, bool isEPOC);
 
-    void setEpoc(bool);
     int getSpeed();
     bool linkFailed();
     void reset();
@@ -109,7 +108,6 @@ private:
 
     // Writing to serial.
 
-    bool isEPOC = false;
     unsigned char *outBuffer; int outWrite = 0; int outRead = 0;
 
     // Initial configuration (const).

--- a/ncpd/link.cc
+++ b/ncpd/link.cc
@@ -162,9 +162,10 @@ sendAck(int seq)
         int lseq = (seq & 7) | 8;
         seq = (hseq << 8) + lseq;
         tmp.prependWord(seq);
-    } else
+    } else {
         tmp.prependByte(seq);
-    dataLink_->send(tmp);
+    }
+    dataLink_->send(tmp, isEPOC_);
 }
 
 void Link::
@@ -185,7 +186,7 @@ sendReqCon()
     pthread_mutex_lock(&queueMutex);
     ackWaitQueue.push_back(e);
     pthread_mutex_unlock(&queueMutex);
-    dataLink_->send(tmp);
+    dataLink_->send(tmp, isEPOC_);
 }
 
 void Link::
@@ -205,7 +206,7 @@ sendReqReq()
     pthread_mutex_lock(&queueMutex);
     ackWaitQueue.push_back(e);
     pthread_mutex_unlock(&queueMutex);
-    dataLink_->send(tmp);
+    dataLink_->send(tmp, isEPOC_);
 }
 
 void Link::
@@ -218,7 +219,7 @@ sendReq()
         lout << "Link: >> con seq=1" << endl;
     tmp.addByte(0x20);
     // No Ack expected for this, so no new entry in ackWaitQueue
-    dataLink_->send(tmp);
+    dataLink_->send(tmp, isEPOC_);
 }
 
 void Link::
@@ -281,11 +282,11 @@ receive(bufferStore buff)
                         default:
                             theNCP->receive(buff);
                     }
-                } else
+                } else {
                     theNCP->receive(buff);
-
+                }
             } else {
-                    sendAck(rxSequence);
+                sendAck(rxSequence);
                 if (verbose & LNK_DEBUG_LOG)
                     lout << "Link: DUP\n";
             }
@@ -323,7 +324,7 @@ receive(bufferStore buff)
                     rxSequence = 0;
                     txSequence = 1;
                     purgeAllQueues();
-                    dataLink_->setEpoc(false);
+                    isEPOC_ = false;
                     if (verbose & LNK_DEBUG_LOG)
                         lout << "Link: 1-linkType set to " << linkType << endl;
                 }
@@ -356,7 +357,7 @@ receive(bufferStore buff)
                             if (verbose & LNK_DEBUG_LOG)
                                 lout << "Link: >> RETRANSMIT seq=" << i->seq
                                      << endl;
-                            dataLink_->send(i->data);
+                            dataLink_->send(i->data, isEPOC_);
                         }
                         break;
                     }
@@ -388,7 +389,7 @@ receive(bufferStore buff)
                         seqMask = 0x7ff;
                         // EPOC can handle up to 8 unacknowledged packets
                         maxOutstanding = 8;
-                        dataLink_->setEpoc(true);
+                        isEPOC_ = true;
                         if (verbose & LNK_DEBUG_LOG) {
                             lout << "Link: << con seq=" << seq ;
                             if (verbose & LNK_DEBUG_DUMP)
@@ -419,7 +420,7 @@ receive(bufferStore buff)
                     seqMask = 0x7ff;
                     // EPOC can handle up to 8 unacknowledged packets
                     maxOutstanding = 8;
-                    dataLink_->setEpoc(true);
+                    isEPOC_ = true;
                     failed = false;
                     sendReqCon();
                 } else {
@@ -433,7 +434,7 @@ receive(bufferStore buff)
                     rxSequence = 0;
                     txSequence = 1; // Our ReqReq was seq 0
                     purgeAllQueues();
-                    dataLink_->setEpoc(false);
+                    isEPOC_ = false;
                     sendAck(rxSequence);
                 }
             }
@@ -542,7 +543,7 @@ transmit(bufferStore buf)
         pthread_mutex_lock(&queueMutex);
         ackWaitQueue.push_back(e);
         pthread_mutex_unlock(&queueMutex);
-        dataLink_->send(buf);
+        dataLink_->send(buf, isEPOC_);
     }
 }
 
@@ -613,7 +614,7 @@ retransmit()
                 i->stamp = now;
                 if (verbose & LNK_DEBUG_LOG)
                     lout << "Link: >> RETRANSMIT seq=" << i->seq << endl;
-                dataLink_->send(i->data);
+                dataLink_->send(i->data, isEPOC_);
             }
         }
     pthread_mutex_unlock(&queueMutex);

--- a/ncpd/link.h
+++ b/ncpd/link.h
@@ -167,6 +167,7 @@ private:
 
     NCP *theNCP;
     DataLink *dataLink_ = nullptr;
+    bool isEPOC_ = false;
     int txSequence;
     int rxSequence;
     int seqMask;


### PR DESCRIPTION
In the current implementation, `DataLink` is only responsible for framing and un-framing data. Given this, it doesn’t make sense for it to have a persistent flag indicating whether it’s connected to an EPOC32 device, especially since this is detected in the owning `Link` class and only required to determine stuffing behavior when writing data.

If the detection needs to move down into `DataLink` in the future, this flag can move back.