### PR TITLE
fix: FreeBSD - use of undeclared identifier ntohs in cli_utils.cc

### DIFF
--- a/lib/cli_utils.cc
+++ b/lib/cli_utils.cc
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 
 #include <netdb.h>
+#include <arpa/inet.h>
 
 bool cli_utils::is_number(const std::string &s) {
     if (s.empty()) {


### PR DESCRIPTION
Fixes issue #132.