### PR TITLE
fix: EPOC16 owner info contains garbage on some systems

### DIFF
--- a/lib/rpcs16.cc
+++ b/lib/rpcs16.cc
@@ -70,7 +70,7 @@ Enum<RFSV::errs> RPCS16::getOwnerInfo(BufferArray &owner) {
     owner.clear();
     for (int i = 0; i < 4; i++) {
         BufferStore b;
-        b.addString(a.getString(52 * i));
+        b.addStringT(a.getString(52 * i));
         owner += b;
     }
 


### PR DESCRIPTION
Since we weren't adding a NULL-terminated string, we were getting garbage on systems where the memory wasn't initialized to zero.