### PR TITLE
fix: Introduce `DeviceConfiguration` class for tracking devices

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -33,9 +33,11 @@ libplp_la_SOURCES = \
 	channel.cc \
 	cli_utils.cc \
 	datalink.cc \
+	deviceconfiguration.cc \
 	drive.cc \
 	Enum.cc \
 	fakepsion.cc \
+	ini.cc \
 	iowatch.cc \
 	link.cc \
 	linkchannel.cc \
@@ -68,6 +70,7 @@ libplp_la_SOURCES = \
 	sistypes.cpp \
 	socketchannel.cc \
 	tcpsocket.cc \
+	uuid.cc \
 	wprt.cc
 
 noinst_HEADERS = \
@@ -76,9 +79,11 @@ noinst_HEADERS = \
 	channel.h \
 	cli_utils.h \
 	datalink.h \
+	deviceconfiguration.h \
 	drive.h \
 	Enum.h \
 	fakepsion.h \
+	ini.h \
 	iowatch.h \
 	link.h  \
 	linkchannel.h \
@@ -113,4 +118,5 @@ noinst_HEADERS = \
 	sistypes.h \
 	socketchannel.h \
 	tcpsocket.h \
+	uuid.h \
 	wprt.h

--- a/lib/deviceconfiguration.cc
+++ b/lib/deviceconfiguration.cc
@@ -40,7 +40,7 @@ std::unique_ptr<DeviceConfiguration> DeviceConfiguration::deserialize(const std:
 }
 
 DeviceConfiguration::DeviceConfiguration()
-: id_(generate_uuid4())
+: id_(uuid::uuid4())
 , name_(_("My Psion")) {
 }
 

--- a/lib/deviceconfiguration.cc
+++ b/lib/deviceconfiguration.cc
@@ -1,0 +1,57 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+
+#include <string>
+#include <unordered_map>
+
+#include "deviceconfiguration.h"
+
+#include "ini.h"
+#include "plpintl.h"
+#include "uuid.h"
+
+std::unique_ptr<DeviceConfiguration> DeviceConfiguration::deserialize(const std::string &stringRepresentation) {
+    auto contents = ini::deserialize(stringRepresentation);
+    if (!contents) {
+        return nullptr;
+    }
+    if (contents->find("id") == contents->end() || contents->find("name") == contents->end()) {
+        return nullptr;
+    }
+    return std::unique_ptr<DeviceConfiguration>(new DeviceConfiguration((*contents)["id"], (*contents)["name"]));
+}
+
+DeviceConfiguration::DeviceConfiguration()
+: id_(generate_uuid4())
+, name_(_("My Psion")) {
+}
+
+DeviceConfiguration::DeviceConfiguration(std::string const &id, std::string const &name)
+: id_(id)
+, name_(name) {
+}
+
+std::string DeviceConfiguration::serialize() const {
+    return ini::serialize({
+        {"id", id_},
+        {"name", name_},
+    });
+}

--- a/lib/deviceconfiguration.h
+++ b/lib/deviceconfiguration.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 

--- a/lib/deviceconfiguration.h
+++ b/lib/deviceconfiguration.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+/**
+* Class for managing and serializing device details.
+*
+* Right now this includes the device identifier string (expected to be a UUID4) and the user-assigned device name.
+*
+* This configuration is generated the first time a device is seen to ensure plptools has a way to uniquely identify it
+* on future connections. This is particularly important for backups.
+*/
+class DeviceConfiguration {
+public:
+
+    DeviceConfiguration();
+
+    DeviceConfiguration(std::string const &id, std::string const &name);
+
+    static std::unique_ptr<DeviceConfiguration> deserialize(const std::string &contents);
+
+    std::string id() const {
+        return id_;
+    }
+
+    std::string name() const {
+        return name_;
+    }
+
+    void setName(std::string name) {
+        name_ = name;
+    }
+
+    std::string serialize() const;
+
+private:
+    std::string id_;
+    std::string name_;
+};

--- a/lib/ini.cc
+++ b/lib/ini.cc
@@ -66,9 +66,14 @@ std::unique_ptr<std::unordered_map<std::string, std::string>> ini::deserialize(c
     for (char c : contents) {
         switch (state) {
         case ParserState::kKeyStart:
-            if (!std::isspace(c)) {
+            if (std::isspace(c)) {
+                // Ignore leading whitespace.
+                continue;
+            } else if (std::isalpha(static_cast<unsigned char>(c))) {
                 currentKey += c;
                 state = ParserState::kKey;
+            } else {
+                return nullptr;
             }
             break;
         case ParserState::kKey:
@@ -76,8 +81,10 @@ std::unique_ptr<std::unordered_map<std::string, std::string>> ini::deserialize(c
                 state = ParserState::kValueStart;
             } else if (std::isspace(c)) {
                 state = ParserState::kKeyEnd;
-            } else {
+            } else if (std::isalpha(static_cast<unsigned char>(c))) {
                 currentKey += c;
+            } else {
+                return nullptr;
             }
             break;
         case ParserState::kKeyEnd:

--- a/lib/ini.cc
+++ b/lib/ini.cc
@@ -59,7 +59,7 @@ std::unique_ptr<std::unordered_map<std::string, std::string>> ini::deserialize(c
         kValueStart,
         kValue,
         kValueWhitespace,
-        kNewline,
+        kValueEnd,
     };
 
     ParserState state = ParserState::kKeyStart;
@@ -95,7 +95,7 @@ std::unique_ptr<std::unordered_map<std::string, std::string>> ini::deserialize(c
             break;
         case ParserState::kValue:
             if (c == '\r') {
-                state = ParserState::kNewline;
+                state = ParserState::kValueEnd;
             } else if (c == '\n') {
                 result[currentKey] = currentValue;
                 currentKey = "";
@@ -112,7 +112,7 @@ std::unique_ptr<std::unordered_map<std::string, std::string>> ini::deserialize(c
         case ParserState::kValueWhitespace:
             if (c == '\r') {
                 currentValueWhitespace = "";
-                state = ParserState::kNewline;
+                state = ParserState::kValueEnd;
             } else if (c == '\n') {
                 result[currentKey] = currentValue;
                 currentKey = "";
@@ -128,7 +128,7 @@ std::unique_ptr<std::unordered_map<std::string, std::string>> ini::deserialize(c
                 state = ParserState::kValue;
             }
             break;
-        case ParserState::kNewline:
+        case ParserState::kValueEnd:
             if (c == '\n') {
                 result[currentKey] = currentValue;
                 currentKey = "";

--- a/lib/ini.cc
+++ b/lib/ini.cc
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "ini.h"
 

--- a/lib/ini.cc
+++ b/lib/ini.cc
@@ -19,6 +19,7 @@
  */
 #include "config.h"
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <unordered_map>

--- a/lib/ini.cc
+++ b/lib/ini.cc
@@ -1,0 +1,158 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+#include "ini.h"
+
+std::string ini::serialize(const std::unordered_map<std::string, std::string> &contents) {
+
+    // Sort the keys to ensure we generate stable output.
+    std::vector<std::string> sortedKeys;
+    sortedKeys.reserve(contents.size());
+    for (const auto& entry : contents) {
+        sortedKeys.push_back(entry.first);
+    }
+    std::sort(sortedKeys.begin(), sortedKeys.end());
+
+    // Iterate over the keys outputting the ini file line.
+    std::ostringstream stream;
+    for (const auto& key : sortedKeys) {
+        stream << key << " = " << contents.at(key) << "\r\n";
+    }
+
+    return stream.str();
+}
+
+std::unique_ptr<std::unordered_map<std::string, std::string>> ini::deserialize(const std::string contents) {
+    std::unordered_map<std::string, std::string> result;
+    std::string currentKey;
+    std::string currentValue;
+    std::string currentValueWhitespace;
+
+    enum class ParserState {
+        kKeyStart,
+        kKey,
+        kKeyEnd,
+        kValueStart,
+        kValue,
+        kValueWhitespace,
+        kNewline,
+    };
+
+    ParserState state = ParserState::kKeyStart;
+    for (char c : contents) {
+        switch (state) {
+        case ParserState::kKeyStart:
+            if (!std::isspace(c)) {
+                currentKey += c;
+                state = ParserState::kKey;
+            }
+            break;
+        case ParserState::kKey:
+            if (c == '=') {
+                state = ParserState::kValueStart;
+            } else if (std::isspace(c)) {
+                state = ParserState::kKeyEnd;
+            } else {
+                currentKey += c;
+            }
+            break;
+        case ParserState::kKeyEnd:
+            if (c == '=') {
+                state = ParserState::kValueStart;
+            } else if (!std::isspace(c)) {
+                return nullptr;
+            }
+            break;
+        case ParserState::kValueStart:
+            if (!std::isspace(c)) {
+                currentValue += c;
+                state = ParserState::kValue;
+            }
+            break;
+        case ParserState::kValue:
+            if (c == '\r') {
+                state = ParserState::kNewline;
+            } else if (c == '\n') {
+                result[currentKey] = currentValue;
+                currentKey = "";
+                currentValue = "";
+                currentValueWhitespace = "";
+                state = ParserState::kKeyStart;
+            } else if (std::isspace(c)) {
+                currentValueWhitespace += c;
+                state = ParserState::kValueWhitespace;
+            } else {
+                currentValue += c;
+            }
+            break;
+        case ParserState::kValueWhitespace:
+            if (c == '\r') {
+                currentValueWhitespace = "";
+                state = ParserState::kNewline;
+            } else if (c == '\n') {
+                result[currentKey] = currentValue;
+                currentKey = "";
+                currentValue = "";
+                currentValueWhitespace = "";
+                state = ParserState::kKeyStart;
+            } else if (std::isspace(c)) {
+                currentValueWhitespace += c;
+            } else {
+                currentValue += currentValueWhitespace;
+                currentValue += c;
+                currentValueWhitespace = "";
+                state = ParserState::kValue;
+            }
+            break;
+        case ParserState::kNewline:
+            if (c == '\n') {
+                result[currentKey] = currentValue;
+                currentKey = "";
+                currentValue = "";
+                currentValueWhitespace = "";
+                state = ParserState::kKeyStart;
+            } else {
+                return nullptr;
+            }
+            break;
+        }
+    }
+
+    // We want to be forgiving of a missing trailing new line, so if we're in state kValue, we emit the last value.
+    // This also resets the parser state to allow us to perform a final integrity check.
+    if (state == ParserState::kValueStart || state == ParserState::kValue || state == ParserState::kValueWhitespace) {
+        result[currentKey] = currentValue;
+        state = ParserState::kKeyStart;
+    }
+
+    // Ensure that we've seen a complete set of lines.
+    if (state != ParserState::kKeyStart) {
+        return nullptr;
+    }
+
+    return std::unique_ptr<std::unordered_map<std::string, std::string>>(
+        new std::unordered_map<std::string, std::string>(std::move(result))
+    );
+}

--- a/lib/ini.h
+++ b/lib/ini.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 

--- a/lib/ini.h
+++ b/lib/ini.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace ini {
+
+/**
+* Simple parser for flat ini data.
+*
+* Does not support sections or quoted values. Supports Windows and Unix line endings.
+*/
+extern std::unique_ptr<std::unordered_map<std::string, std::string>> deserialize(const std::string contents);
+
+/**
+* Outputs simple flat ini data.
+*
+* Does not currently attempt to quote values (multi-line strings and strings with trailing whitespace will break this.)
+*/
+extern std::string serialize(const std::unordered_map<std::string, std::string> &contents);
+
+};

--- a/lib/uuid.cc
+++ b/lib/uuid.cc
@@ -23,6 +23,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstdio>
 
 constexpr size_t kUUID4Size = 16;
 

--- a/lib/uuid.cc
+++ b/lib/uuid.cc
@@ -22,10 +22,11 @@
 #include "uuid.h"
 
 #include <array>
+#include <cstdint>
 
 constexpr size_t kUUID4Size = 16;
 
-std::string generate_uuid4() {
+std::string uuid::uuid4() {
     std::array<uint8_t, kUUID4Size> b;
 
     FILE* f = fopen("/dev/urandom", "rb");

--- a/lib/uuid.cc
+++ b/lib/uuid.cc
@@ -1,0 +1,57 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+
+#include "uuid.h"
+
+#include <array>
+
+constexpr size_t kUUID4Size = 16;
+
+std::string generate_uuid4() {
+    std::array<uint8_t, kUUID4Size> b;
+
+    FILE* f = fopen("/dev/urandom", "rb");
+    if (!f) {
+        fprintf(stderr, "Failed to open /dev/urandom while generating UUID4.\n");
+        abort();
+    }
+
+    int count = fread(b.data(), 1, kUUID4Size, f);
+    fclose(f);
+    if (count != kUUID4Size) {
+        fprintf(stderr, "Failed to read from /dev/urandom while generating UUID4.\n");
+        abort();
+    }
+
+    // Mask the version and variant into the random data.
+    b[6] = (b[6] & 0x0F) | 0x40;  // 4
+    b[8] = (b[8] & 0x3F) | 0x80;  // RFC 4122
+
+    char buf[37];
+    snprintf(buf, sizeof(buf),
+             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             b[0],  b[1],  b[2],  b[3],
+             b[4],  b[5],  b[6],  b[7],
+             b[8],  b[9],  b[10], b[11],
+             b[12], b[13], b[14], b[15]);
+
+    return std::string(buf);
+}

--- a/lib/uuid.h
+++ b/lib/uuid.h
@@ -25,4 +25,4 @@ namespace uuid {
 
 extern std::string uuid4();
 
-};
+}

--- a/lib/uuid.h
+++ b/lib/uuid.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <string>
+
+extern std::string generate_uuid4();

--- a/lib/uuid.h
+++ b/lib/uuid.h
@@ -21,4 +21,8 @@
 
 #include <string>
 
-extern std::string generate_uuid4();
+namespace uuid {
+
+extern std::string uuid4();
+
+};

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,8 +24,10 @@ tests_CPPFLAGS = -DPKGDATADIR="\"$(pkgdatadir)\"" -I$(top_srcdir)/lib -I$(top_sr
 tests_CXXFLAGS = $(WARN_CXXFLAGS)
 tests_LDADD = $(LIB_PLP) $(INTLLIBS) $(SERVENT_LIB)
 tests_SOURCES = \
+    deviceconfigurationtests.cc \
     doctest.h \
     drivetests.cc \
+    initests.cc \
     main.cc \
     pathutilstests.cc \
     plpdirenttests.cc

--- a/tests/deviceconfigurationtests.cc
+++ b/tests/deviceconfigurationtests.cc
@@ -1,0 +1,61 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+
+#include <iostream>
+#include <ostream>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "doctest.h"
+#include "deviceconfiguration.h"
+#include "pathutils.h"
+#include "uuid.h"
+
+TEST_CASE("DeviceConfiguration accessors") {
+    std::string id = generate_uuid4();
+    DeviceConfiguration configuration(id, "My Psion");
+    CHECK(configuration.id() == id);
+    CHECK(configuration.name() == "My Psion");
+}
+
+TEST_CASE("DeviceConfiguration::serialize") {
+    DeviceConfiguration configuration("12345", "My Psion");
+    CHECK(configuration.serialize() == "id = 12345\r\nname = My Psion\r\n");
+}
+
+TEST_CASE("DeviceConfiguration::deserialize") {
+
+    SUBCASE("non-empty name") {
+        DeviceConfiguration configuration("123456", "My Psion");
+        std::string stringRepresentation = configuration.serialize();
+        auto result = DeviceConfiguration::deserialize(stringRepresentation);
+        CHECK(result->id() == "123456");
+        CHECK(result->name() == "My Psion");
+    }
+
+    SUBCASE("empty name") {
+        DeviceConfiguration configuration("123456", "");
+        std::string stringRepresentation = configuration.serialize();
+        auto result = DeviceConfiguration::deserialize(stringRepresentation);
+        CHECK(result->id() == "123456");
+        CHECK(result->name() == "");
+    }
+}

--- a/tests/deviceconfigurationtests.cc
+++ b/tests/deviceconfigurationtests.cc
@@ -30,7 +30,7 @@
 #include "uuid.h"
 
 TEST_CASE("DeviceConfiguration accessors") {
-    std::string id = generate_uuid4();
+    std::string id = uuid::uuid4();
     DeviceConfiguration configuration(id, "My Psion");
     CHECK(configuration.id() == id);
     CHECK(configuration.name() == "My Psion");

--- a/tests/initests.cc
+++ b/tests/initests.cc
@@ -44,9 +44,17 @@ TEST_CASE("parse_ini") {
         CHECK(contents->empty());
     }
 
-    SUBCASE("corrupt") {
+    SUBCASE("corrupt fails") {
         REQUIRE(ini::deserialize("broken") == nullptr);
         REQUIRE(ini::deserialize("a=b\nbroken") == nullptr);
+    }
+
+    SUBCASE("missing key fails") {
+        REQUIRE(ini::deserialize("=value\n") == nullptr);
+    }
+
+    SUBCASE("non-alpha key fails") {
+        REQUIRE(ini::deserialize("some2=value\n") == nullptr);
     }
 
     SUBCASE("single value") {

--- a/tests/initests.cc
+++ b/tests/initests.cc
@@ -1,0 +1,99 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+
+#include <iostream>
+#include <ostream>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "doctest.h"
+#include "deviceconfiguration.h"
+#include "pathutils.h"
+#include "uuid.h"
+#include "ini.h"
+
+TEST_CASE("parse_ini") {
+
+    SUBCASE("empty string") {
+        auto contents = ini::deserialize("");
+        REQUIRE(contents != nullptr);
+        CHECK(contents->empty());
+    }
+
+    SUBCASE("multiple new lines") {
+        auto contents = ini::deserialize("\r\n\r\n\r\n");
+        REQUIRE(contents != nullptr);
+        CHECK(contents->empty());
+    }
+
+    SUBCASE("corrupt") {
+        REQUIRE(ini::deserialize("broken") == nullptr);
+        REQUIRE(ini::deserialize("a=b\nbroken") == nullptr);
+    }
+
+    SUBCASE("single value") {
+        auto contents = ini::deserialize("key = bar\r\n");
+        REQUIRE(contents != nullptr);
+        CHECK(*contents == std::unordered_map<std::string, std::string>{
+            {"key", "bar"}
+        });
+    }
+
+    SUBCASE("empty value") {
+        auto contents = ini::deserialize("key=\r\n");
+        REQUIRE(contents != nullptr);
+        CHECK(*contents == std::unordered_map<std::string, std::string>{
+            {"key", ""}
+        });
+    }
+
+    SUBCASE("missing newline") {
+        auto contents = ini::deserialize("key = bar");
+        REQUIRE(contents != nullptr);
+        CHECK(*contents == std::unordered_map<std::string, std::string>{
+            {"key", "bar"}
+        });
+    }
+
+    SUBCASE("ignore trailing whitespace with missing newline") {
+        auto contents = ini::deserialize("key = bar  ");
+        REQUIRE(contents != nullptr);
+        CHECK(*contents == std::unordered_map<std::string, std::string>{
+            {"key", "bar"}
+        });
+    }
+
+    SUBCASE("ignore trailing whitespace") {
+        auto contents = ini::deserialize("key = bar  \n");
+        REQUIRE(contents != nullptr);
+        CHECK(*contents == std::unordered_map<std::string, std::string>{
+            {"key", "bar"}
+        });
+    }
+
+    SUBCASE("ignore trailing whitespace (windows line ending)") {
+        auto contents = ini::deserialize("key = bar  \r\n");
+        REQUIRE(contents != nullptr);
+        CHECK(*contents == std::unordered_map<std::string, std::string>{
+            {"key", "bar"}
+        });
+    }
+}


### PR DESCRIPTION
This change introduces a new `DeviceConfiguration` class which can be used to serialize device identifiers and names. It represents preparatory work for writing these to devices on first-connection so we can generate stable identifiers for use in backups and other multi-session operations like sync.