### PR TITLE
ci: Adopt the new MacFUSE MFMount framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
             setup: |
               brew install coreutils readline pkg-config libtool automake gettext macfuse
               echo "$(brew --prefix m4)/bin:/usr/local/opt/gettext/bin" >> $GITHUB_PATH
-              echo "LDFLAGS=-L$(brew --prefix readline)/lib -L/Library/Filesystems/macfuse.fs/Contents/Frameworks" >> "$GITHUB_ENV"
+              echo "LDFLAGS=-L$(brew --prefix readline)/lib -F/Library/Filesystems/macfuse.fs/Contents/Frameworks" >> "$GITHUB_ENV"
               echo "CPPFLAGS=-I$(brew --prefix readline)/include" >> "$GITHUB_ENV"
 
     name: ${{ matrix.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
               apt-get install -y build-essential git libtool gpg pkg-config gettext autopoint libreadline-dev
 
           - name: macos-latest
-            os: macos-latest
+            os: macos-26
             setup: |
               brew install coreutils readline pkg-config libtool automake gettext macfuse
               echo "$(brew --prefix m4)/bin:/usr/local/opt/gettext/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,16 @@ jobs:
               apt-get update -y
               apt-get install -y build-essential git libtool gpg pkg-config gettext autopoint libreadline-dev
 
-          - name: macos-latest
+          - name: macos-26
             os: macos-26
+            setup: |
+              brew install coreutils readline pkg-config libtool automake gettext macfuse
+              echo "$(brew --prefix m4)/bin:/usr/local/opt/gettext/bin" >> $GITHUB_PATH
+              echo "LDFLAGS=-L$(brew --prefix readline)/lib -F/Library/Filesystems/macfuse.fs/Contents/Frameworks" >> "$GITHUB_ENV"
+              echo "CPPFLAGS=-I$(brew --prefix readline)/include" >> "$GITHUB_ENV"
+
+          - name: macos-15
+            os: macos-15
             setup: |
               brew install coreutils readline pkg-config libtool automake gettext macfuse
               echo "$(brew --prefix m4)/bin:/usr/local/opt/gettext/bin" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
             setup: |
               brew install coreutils readline pkg-config libtool automake gettext macfuse
               echo "$(brew --prefix m4)/bin:/usr/local/opt/gettext/bin" >> $GITHUB_PATH
-              echo "LDFLAGS=-L$(brew --prefix readline)/lib" >> "$GITHUB_ENV"
+              echo "LDFLAGS=-L$(brew --prefix readline)/lib -L/Library/Filesystems/macfuse.fs/Contents/Frameworks" >> "$GITHUB_ENV"
               echo "CPPFLAGS=-I$(brew --prefix readline)/include" >> "$GITHUB_ENV"
 
     name: ${{ matrix.name }}

--- a/build-aux/setup-mac-development.sh
+++ b/build-aux/setup-mac-development.sh
@@ -43,7 +43,7 @@ export PATH="$(brew --prefix m4)/bin:$PATH"
 
 # Configure.
 export CPPFLAGS="-I$(brew --prefix gettext)/include -I$(brew --prefix readline)/include"
-export LDFLAGS="-L$(brew --prefix gettext)/lib -L$(brew --prefix readline)/lib"
+export LDFLAGS="-L$(brew --prefix gettext)/lib -L$(brew --prefix readline)/lib -F/Library/Filesystems/macfuse.fs/Contents/Frameworks"
 ./configure \
     --prefix="$BUILD_DIRECTORY" \
     CFLAGS="-g -O0" \


### PR DESCRIPTION
This change updates the macOS build scripts to link the new MacFUSE MFMount framework. This change is inline with the new work in MacFUSE to adopt Apple's FSKit which will hopefully allow `plpfuse` to used without effectively rooting your Mac.

Includes a drive-by fix to add explicit macOS 26 and 15 builds.