### PR TITLE
refactor: Simplify `RFSV` socket ownership

### DIFF
--- a/lib/psion.cpp
+++ b/lib/psion.cpp
@@ -22,6 +22,7 @@
 #include "psion.h"
 
 #include <cli_utils.h>
+#include <memory>
 #include <plpintl.h>
 #include <rfsv.h>
 #include <rpcs.h>
@@ -42,18 +43,15 @@ Psion::~Psion() {
 
 bool Psion::connect() {
     int sockNum = cli_utils::lookup_default_port();
-    rfsvSocket_ = new TCPSocket();
-    if (!rfsvSocket_->connect(NULL, sockNum)) {
-        return false;
-    }
     rpcsSocket_ = new TCPSocket();
     if (!rpcsSocket_->connect(NULL, sockNum)) {
         return false;
     }
-    rfsvFactory_ = new RFSVFactory(rfsvSocket_);
-    rpcsFactory_ = new RPCSFactory(rpcsSocket_);
-    rfsv_ = rfsvFactory_->create(true);
-    rpcs_ = rpcsFactory_->create(true);
+
+    auto rfsvFactory = std::make_unique<RFSVFactory>("127.0.0.1", sockNum);
+    auto rpcsFactory = std::make_unique<RPCSFactory>(rpcsSocket_);
+    rfsv_ = rfsvFactory->create(true);
+    rpcs_ = rpcsFactory->create(true);
     if ((rfsv_ != NULL) && (rpcs_ != NULL)) {
         return true;
     }
@@ -103,21 +101,9 @@ void Psion::disconnect() {
         delete rpcs_;
         rpcs_ = nullptr;
     }
-    if (rfsvSocket_) {
-        delete rfsvSocket_;
-        rfsvSocket_ = nullptr;
-    }
     if (rpcsSocket_) {
         delete rpcsSocket_;
         rpcsSocket_ = nullptr;
-    }
-    if (rfsvFactory_) {
-        delete rfsvFactory_;
-        rfsvFactory_ = nullptr;
-    }
-    if (rpcsFactory_) {
-        delete rpcsFactory_;
-        rpcsFactory_ = nullptr;
     }
 }
 

--- a/lib/psion.h
+++ b/lib/psion.h
@@ -61,10 +61,7 @@ public:
 
 private:
 
-    TCPSocket* rfsvSocket_;
     TCPSocket* rpcsSocket_;
-    RFSVFactory* rfsvFactory_;
-    RPCSFactory* rpcsFactory_;
     RPCS* rpcs_;
     RFSV* rfsv_;
 

--- a/lib/rfsv.h
+++ b/lib/rfsv.h
@@ -654,7 +654,7 @@ protected:
     */
     const char *getConnectName();
 
-    TCPSocket *socket_;
+    std::unique_ptr<TCPSocket> socket_;
     Enum<errs> status_;
     int32_t operationId_;
 };

--- a/lib/rfsv.h
+++ b/lib/rfsv.h
@@ -23,6 +23,7 @@
 #define _RFSV_H_
 
 #include <deque>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/lib/rfsv16.cc
+++ b/lib/rfsv16.cc
@@ -43,10 +43,10 @@
 
 using namespace std;
 
-RFSV16::RFSV16(TCPSocket *socket) {
+RFSV16::RFSV16(std::unique_ptr<TCPSocket> socket) {
     operationId_ = 0;
     status_ = RFSV::E_PSI_FILE_DISC;
-    socket_ = socket;
+    socket_ = std::move(socket);
     reset();
 }
 

--- a/lib/rfsv16.h
+++ b/lib/rfsv16.h
@@ -22,6 +22,7 @@
 #define _RFSV16_H_
 
 #include "rfsv.h"
+#include <memory>
 
 class RFSVFactory;
 
@@ -135,10 +136,9 @@ private:
     };
 
     /**
-    * Private constructor. Shall be called by
-    * RFSVFactory only.
+    * Private constructor. Shall be called by RFSVFactory only.
     */
-    RFSV16(TCPSocket *);
+    RFSV16(std::unique_ptr<TCPSocket> socket);
 
     // Miscellaneous
     Enum<RFSV::errs> fopendir(const char * const, uint32_t &);

--- a/lib/rfsv32.cc
+++ b/lib/rfsv32.cc
@@ -36,8 +36,8 @@
 
 using namespace std;
 
-RFSV32::RFSV32(TCPSocket *socket) {
-    socket_ = socket;
+RFSV32::RFSV32(std::unique_ptr<TCPSocket> socket) {
+    socket_ = std::move(socket);
     operationId_ = 0;
     status_ = RFSV::E_PSI_FILE_DISC;
     reset();

--- a/lib/rfsv32.h
+++ b/lib/rfsv32.h
@@ -192,13 +192,12 @@ private:
     * Private constructor. Shall be called by
     * RFSVFactory only.
     */
-    RFSV32(TCPSocket *);
+    RFSV32(std::unique_ptr<TCPSocket> socket);
 
     Enum<RFSV::errs> err2psierr(int32_t);
     Enum<RFSV::errs> fopendir(const uint32_t, const char *, uint32_t &);
     uint32_t attr2std(const uint32_t);
     uint32_t std2attr(const uint32_t);
-
 
     // Communication
     bool sendCommand(enum commands, BufferStore &);

--- a/lib/rfsvfactory.cc
+++ b/lib/rfsvfactory.cc
@@ -41,56 +41,60 @@ ENUM_DEFINITION_BEGIN(RFSVFactory::errs, RFSVFactory::FACERR_NONE)
     stringRep.add(RFSVFactory::FACERR_NORESPONSE,     N_("no response from ncpd"));
 ENUM_DEFINITION_END(RFSVFactory::errs)
 
-RFSVFactory::RFSVFactory(TCPSocket *_skt)
-: serNum(0) {
-    err = FACERR_NONE;
-    skt = _skt;
-}
+RFSVFactory::RFSVFactory(const std::string &host, int port)
+: host_(host)
+, port_(port)
+, serNum_(0)
+, error_(FACERR_NONE) {}
 
 RFSVFactory::~RFSVFactory() {
 }
 
 RFSV* RFSVFactory::create(bool reconnect) {
-    // skt is connected to the ncp daemon, which will have (hopefully) seen
-    // an INFO exchange, where the protocol version of the remote Psion was
-    // sent, and noted. We have to ask the ncp daemon which protocol it saw,
-    // so we can instantiate the correct RFSV protocol handler for the
-    // caller. We announce ourselves to the NCP daemon, and the relevant
-    // RFSV module will also announce itself.
+
+    auto socket = std::make_unique<TCPSocket>();
+    if (!socket->connect(host_.c_str(), port_)) {
+        cout << _("could not connect to ncpd") << endl;
+        return nullptr;
+    }
+
+    // At this point the socket is connected to the ncp daemon, which will have (hopefully) seen an INFO exchange, where
+    // the protocol version of the remote Psion was sent, and noted. We have to ask the ncp daemon which protocol it
+    // saw, so we can instantiate the correct RFSV protocol handler for the caller. We announce ourselves to the NCP
+    // daemon, and the relevant RFSV module will also announce itself.
 
     BufferStore a;
-
-    err = FACERR_NONE;
+    error_ = FACERR_NONE;
     a.addStringT("NCP$INFO");
-    if (!skt->sendBufferStore(a)) {
+    if (!socket->sendBufferStore(a)) {
         if (!reconnect)
-            err = FACERR_COULD_NOT_SEND;
+            error_ = FACERR_COULD_NOT_SEND;
         else {
-            skt->closeSocket();
-            serNum = 0;
-            skt->reconnect();
-            err = FACERR_AGAIN;
+            socket->closeSocket();
+            serNum_ = 0;
+            socket->reconnect();
+            error_ = FACERR_AGAIN;
         }
         return NULL;
     }
-    if (skt->getBufferStore(a) == 1) {
+    if (socket->getBufferStore(a) == 1) {
         if (a.getLen() > 8 && !strncmp(a.getString(), "Series 3", 8)) {
-            return new RFSV16(skt);
+            return new RFSV16(std::move(socket));
         }
         else if (a.getLen() > 8 && !strncmp(a.getString(), "Series 5", 8)) {
-            return new RFSV32(skt);
+            return new RFSV32(std::move(socket));
         }
         if ((a.getLen() > 8) && !strncmp(a.getString(), "No Psion", 8)) {
-            skt->closeSocket();
-            serNum = 0;
-            skt->reconnect();
-            err = FACERR_NOPSION;
+            socket->closeSocket();
+            serNum_ = 0;
+            socket->reconnect();
+            error_ = FACERR_NOPSION;
             return NULL;
         }
         // Invalid protocol version
-        err = FACERR_PROTVERSION;
+        error_ = FACERR_PROTVERSION;
     } else
-        err = FACERR_NORESPONSE;
+        error_ = FACERR_NORESPONSE;
 
     return NULL;
 }

--- a/lib/rfsvfactory.cc
+++ b/lib/rfsvfactory.cc
@@ -44,8 +44,7 @@ ENUM_DEFINITION_END(RFSVFactory::errs)
 
 RFSVFactory::RFSVFactory(const std::string &host, int port)
 : host_(host)
-, port_(port)
-, serNum_(0) {}
+, port_(port) {}
 
 RFSVFactory::~RFSVFactory() {
 }
@@ -78,7 +77,6 @@ RFSV* RFSVFactory::create(bool reconnect, Enum<errs> *error) {
             }
         } else {
             socket->closeSocket();
-            serNum_ = 0;
             socket->reconnect();
             if (error) {
                 *error = FACERR_AGAIN;
@@ -95,7 +93,6 @@ RFSV* RFSVFactory::create(bool reconnect, Enum<errs> *error) {
         }
         if ((a.getLen() > 8) && !strncmp(a.getString(), "No Psion", 8)) {
             socket->closeSocket();
-            serNum_ = 0;
             socket->reconnect();
             if (error) {
                 *error = FACERR_NOPSION;

--- a/lib/rfsvfactory.cc
+++ b/lib/rfsvfactory.cc
@@ -33,28 +33,34 @@
 using namespace std;
 
 ENUM_DEFINITION_BEGIN(RFSVFactory::errs, RFSVFactory::FACERR_NONE)
-    stringRep.add(RFSVFactory::FACERR_NONE,           N_("no error"));
-    stringRep.add(RFSVFactory::FACERR_COULD_NOT_SEND, N_("could not send version request"));
-    stringRep.add(RFSVFactory::FACERR_AGAIN,          N_("try again"));
-    stringRep.add(RFSVFactory::FACERR_NOPSION,        N_("no EPOC device connected"));
-    stringRep.add(RFSVFactory::FACERR_PROTVERSION,    N_("wrong protocol version"));
-    stringRep.add(RFSVFactory::FACERR_NORESPONSE,     N_("no response from ncpd"));
+    stringRep.add(RFSVFactory::FACERR_NONE,               N_("no error"));
+    stringRep.add(RFSVFactory::FACERR_COULD_NOT_SEND,     N_("could not send version request"));
+    stringRep.add(RFSVFactory::FACERR_AGAIN,              N_("try again"));
+    stringRep.add(RFSVFactory::FACERR_NOPSION,            N_("no EPOC device connected"));
+    stringRep.add(RFSVFactory::FACERR_PROTVERSION,        N_("wrong protocol version"));
+    stringRep.add(RFSVFactory::FACERR_NORESPONSE,         N_("no response from ncpd"));
+    stringRep.add(RFSVFactory::FACERR_CONNECTION_FAILURE, N_("could not connect to ncpd"));
 ENUM_DEFINITION_END(RFSVFactory::errs)
 
 RFSVFactory::RFSVFactory(const std::string &host, int port)
 : host_(host)
 , port_(port)
-, serNum_(0)
-, error_(FACERR_NONE) {}
+, serNum_(0) {}
 
 RFSVFactory::~RFSVFactory() {
 }
 
-RFSV* RFSVFactory::create(bool reconnect) {
+RFSV* RFSVFactory::create(bool reconnect, Enum<errs> *error) {
+
+    if (error) {
+        *error = FACERR_NONE;
+    }
 
     auto socket = std::make_unique<TCPSocket>();
     if (!socket->connect(host_.c_str(), port_)) {
-        cout << _("could not connect to ncpd") << endl;
+        if (error) {
+            *error = FACERR_CONNECTION_FAILURE;
+        }
         return nullptr;
     }
 
@@ -64,16 +70,19 @@ RFSV* RFSVFactory::create(bool reconnect) {
     // daemon, and the relevant RFSV module will also announce itself.
 
     BufferStore a;
-    error_ = FACERR_NONE;
     a.addStringT("NCP$INFO");
     if (!socket->sendBufferStore(a)) {
-        if (!reconnect)
-            error_ = FACERR_COULD_NOT_SEND;
-        else {
+        if (!reconnect) {
+            if (error) {
+                *error = FACERR_COULD_NOT_SEND;
+            }
+        } else {
             socket->closeSocket();
             serNum_ = 0;
             socket->reconnect();
-            error_ = FACERR_AGAIN;
+            if (error) {
+                *error = FACERR_AGAIN;
+            }
         }
         return NULL;
     }
@@ -88,13 +97,19 @@ RFSV* RFSVFactory::create(bool reconnect) {
             socket->closeSocket();
             serNum_ = 0;
             socket->reconnect();
-            error_ = FACERR_NOPSION;
+            if (error) {
+                *error = FACERR_NOPSION;
+            }
             return NULL;
         }
         // Invalid protocol version
-        error_ = FACERR_PROTVERSION;
+        if (error) {
+            *error = FACERR_PROTVERSION;
+        }
     } else
-        error_ = FACERR_NORESPONSE;
+        if (error) {
+            *error = FACERR_NORESPONSE;
+        }
 
     return NULL;
 }

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "rfsv.h"
+#include <cstddef>
 
 class TCPSocket;
 
@@ -41,7 +42,8 @@ public:
         FACERR_AGAIN = 2,
         FACERR_NOPSION = 3,
         FACERR_PROTVERSION = 4,
-        FACERR_NORESPONSE = 5
+        FACERR_NORESPONSE = 5,
+        FACERR_CONNECTION_FAILURE = 6,
     };
 
     /**
@@ -60,25 +62,15 @@ public:
     /**
     * Creates a new @ref RFSV instance.
     *
-    * @param reconnect Set to true, if automatic reconnect
-    * should be performed on failure.
+    * @param reconnect Set to true, if automatic reconnect should be performed on failure.
+    * @param error Out parameter; set to the error on failure if non-NULL.
     *
-    * @returns A pointer to a newly created rfsv instance or
-    * NULL on failure.
+    * @returns A pointer to a newly created @ref RFSV instance or NULL on failure.
     */
-    virtual RFSV* create(bool);
-
-    /**
-    * Retrieve an error code.
-    *
-    * @returns The error code, in case @ref create has
-    * failed, 0 otherwise.
-    */
-    virtual Enum<errs> getError() { return error_; }
+    virtual RFSV* create(bool, Enum<errs> *error = nullptr);
 
 private:
     std::string host_;
     int port_;
     int serNum_;
-    Enum<errs> error_;
 };

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -52,7 +52,7 @@ public:
     * @param skt The socket to be used for connecting
     * to the ncpd daemon.
     */
-    RFSVFactory(TCPSocket *skt);
+    RFSVFactory(const std::string &host, int port);
 
     /**
      * Delete the RFSVFactory, cleaning up any resources.
@@ -76,14 +76,11 @@ public:
     * @returns The error code, in case @ref create has
     * failed, 0 otherwise.
     */
-    virtual Enum<errs> getError() { return err; }
+    virtual Enum<errs> getError() { return error_; }
 
 private:
-    /**
-    * The socket to be used for connecting to the
-    * ncpd daemon.
-    */
-    TCPSocket *skt;
-    int serNum;
-    Enum<errs> err;
+    std::string host_;
+    int port_;
+    int serNum_;
+    Enum<errs> error_;
 };

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -72,5 +72,4 @@ public:
 private:
     std::string host_;
     int port_;
-    int serNum_;
 };

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -49,8 +49,8 @@ public:
     *
     * Does not take ownership of the socket.
     *
-    * @param skt The socket to be used for connecting
-    * to the ncpd daemon.
+    * @param host The host be used for connecting to the ncpd daemon.
+    * @param port The port be used for connecting to the ncpd daemon.
     */
     RFSVFactory(const std::string &host, int port);
 

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -47,8 +47,6 @@ public:
     /**
     * Constructs a RFSVFactory.
     *
-    * Does not take ownership of the socket.
-    *
     * @param host The host be used for connecting to the ncpd daemon.
     * @param port The port be used for connecting to the ncpd daemon.
     */

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -127,8 +127,9 @@ int main(int argc, char **argv) {
                 break;
         }
     }
-    if (optind == argc)
+    if (optind == argc) {
         ftpHeader();
+    }
 
     skt2 = new TCPSocket();
     if (!skt2->connect(host.c_str(), sockNum)) {
@@ -137,7 +138,9 @@ int main(int argc, char **argv) {
     }
     auto rf = std::make_unique<RFSVFactory>(host, sockNum);
     auto rp = std::make_unique<RPCSFactory>(skt2);
-    a = rf->create(false);
+
+    Enum<RFSVFactory::errs> error;
+    a = rf->create(false, &error);
     r = rp->create(false);
     rclipSocket = new TCPSocket();
     rclipSocket->connect(NULL, sockNum);
@@ -157,7 +160,7 @@ int main(int argc, char **argv) {
             delete rc;
         }
     } else {
-        cerr << "plpftp: " << rf->getError() << endl;
+        cerr << "plpftp: " << error << endl;
         status = 1;
     }
     return status;

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include <cli_utils.h>
+#include <memory>
 #include <rfsv.h>
 #include <rfsvfactory.h>
 #include <rpcs.h>
@@ -91,7 +92,6 @@ void ftpHeader() {
 }
 
 int main(int argc, char **argv) {
-    TCPSocket *skt;
     TCPSocket *skt2;
     RFSV *a;
     RPCS *r;
@@ -130,18 +130,13 @@ int main(int argc, char **argv) {
     if (optind == argc)
         ftpHeader();
 
-    skt = new TCPSocket();
-    if (!skt->connect(host.c_str(), sockNum)) {
-        cout << _("plpftp: could not connect to ncpd") << endl;
-        return 1;
-    }
     skt2 = new TCPSocket();
     if (!skt2->connect(host.c_str(), sockNum)) {
         cout << _("plpftp: could not connect to ncpd") << endl;
         return 1;
     }
-    RFSVFactory *rf = new RFSVFactory(skt);
-    RPCSFactory *rp = new RPCSFactory(skt2);
+    auto rf = std::make_unique<RFSVFactory>(host, sockNum);
+    auto rp = std::make_unique<RPCSFactory>(skt2);
     a = rf->create(false);
     r = rp->create(false);
     rclipSocket = new TCPSocket();
@@ -155,7 +150,6 @@ int main(int argc, char **argv) {
         status = f.session(*a, *r, *rc, *rclipSocket, args);
         delete r;
         delete a;
-        delete skt;
         delete skt2;
         if (rclipSocket)
             delete rclipSocket;
@@ -166,7 +160,5 @@ int main(int argc, char **argv) {
         cerr << "plpftp: " << rf->getError() << endl;
         status = 1;
     }
-    delete rf;
-    delete rp;
     return status;
 }

--- a/plpfuse/main.cc
+++ b/plpfuse/main.cc
@@ -381,7 +381,7 @@ int fuse(int argc, char *argv[])
 }
 
 int main(int argc, char**argv) {
-    TCPSocket *skt, *skt2;
+    TCPSocket *skt2;
     string host = "127.0.0.1";
     int sockNum = DPORT, i, c, oldoptind = 1;
 
@@ -418,18 +418,13 @@ int main(int argc, char**argv) {
             break;
     }
 
-    skt = new TCPSocket();
-    if (!skt->connect(host.c_str(), sockNum)) {
-        cerr << _("plpfuse: could not connect to ncpd") << endl;
-        return 1;
-    }
     skt2 = new TCPSocket();
     if (!skt2->connect(host.c_str(), sockNum)) {
         cerr << _("plpfuse: could not connect to ncpd") << endl;
         return 1;
     }
 
-    rf = new RFSVFactory(skt);
+    rf = new RFSVFactory(host.c_str(), sockNum);
     rp = new RPCSFactory(skt2);
     a = rf->create(true);
     r = rp->create(true);


### PR DESCRIPTION
This changes `RFSV` to own its `TCPSocket` instance and makes it responsible for cleanup on deletion. It introduces `std::unique_ptr` as a way to make this ownership model clear.

This change is a pipe cleaner for tidying up the `RPCS` and `rclip` socket lifecycles and reducing the amount of boilerplate required to connect to ncpd.