### PR TITLE
refactor: Simplify `RPCS` and `rclip` socket ownership

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -30,6 +30,7 @@ libplp_la_LIBADD = $(INTLLIBS) $(LIBPMULTITHREAD) $(LIBTHREAD) $(NANOSLEEP_LIB) 
 libplp_la_SOURCES = \
 	bufferarray.cc \
 	bufferstore.cc \
+	connectionerror.cc \
 	channel.cc \
 	cli_utils.cc \
 	datalink.cc \
@@ -76,6 +77,7 @@ libplp_la_SOURCES = \
 noinst_HEADERS = \
 	bufferarray.h \
 	bufferstore.h \
+	connectionerror.h \
 	channel.h \
 	cli_utils.h \
 	datalink.h \

--- a/lib/connectionerror.cc
+++ b/lib/connectionerror.cc
@@ -1,0 +1,36 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (C) 1999 Philip Proudman <philip.proudman@btinternet.com>
+ *  Copyright (C) 1999 Matt J. Gumbley <matt@gumbley.demon.co.uk>
+ *  Copyright (C) 1999-2001 Fritz Elfert <felfert@to.com>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+
+#include "connectionerror.h"
+#include "Enum.h"
+
+ENUM_DEFINITION_BEGIN(ConnectionError, ConnectionError::FACERR_NONE)
+    stringRep.add(ConnectionError::FACERR_NONE,               N_("no error"));
+    stringRep.add(ConnectionError::FACERR_COULD_NOT_SEND,     N_("could not send version request"));
+    stringRep.add(ConnectionError::FACERR_AGAIN,              N_("try again"));
+    stringRep.add(ConnectionError::FACERR_NOPSION,            N_("no EPOC device connected"));
+    stringRep.add(ConnectionError::FACERR_PROTVERSION,        N_("wrong protocol version"));
+    stringRep.add(ConnectionError::FACERR_NORESPONSE,         N_("no response from ncpd"));
+    stringRep.add(ConnectionError::FACERR_CONNECTION_FAILURE, N_("could not connect to ncpd"));
+ENUM_DEFINITION_END(ConnectionError)

--- a/lib/connectionerror.h
+++ b/lib/connectionerror.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (C) 1999 Philip Proudman <philip.proudman@btinternet.com>
+ *  Copyright (C) 1999 Matt J. Gumbley <matt@gumbley.demon.co.uk>
+ *  Copyright (C) 1999-2001 Fritz Elfert <felfert@to.com>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+* Errors that can occur when connecting to a PLP server.
+*/
+enum ConnectionError {
+    FACERR_NONE = 0,
+    FACERR_COULD_NOT_SEND = 1,
+    FACERR_AGAIN = 2,
+    FACERR_NOPSION = 3,
+    FACERR_PROTVERSION = 4,
+    FACERR_NORESPONSE = 5,
+    FACERR_CONNECTION_FAILURE = 6,
+};

--- a/lib/psion.cpp
+++ b/lib/psion.cpp
@@ -43,13 +43,9 @@ Psion::~Psion() {
 
 bool Psion::connect() {
     int sockNum = cli_utils::lookup_default_port();
-    rpcsSocket_ = new TCPSocket();
-    if (!rpcsSocket_->connect(NULL, sockNum)) {
-        return false;
-    }
-
-    auto rfsvFactory = std::make_unique<RFSVFactory>("127.0.0.1", sockNum);
-    auto rpcsFactory = std::make_unique<RPCSFactory>(rpcsSocket_);
+    std::string host = "127.0.0.1";
+    auto rfsvFactory = std::make_unique<RFSVFactory>(host, sockNum);
+    auto rpcsFactory = std::make_unique<RPCSFactory>(host, sockNum);
     rfsv_ = rfsvFactory->create(true);
     rpcs_ = rpcsFactory->create(true);
     if ((rfsv_ != NULL) && (rpcs_ != NULL)) {
@@ -100,10 +96,6 @@ void Psion::disconnect() {
     if (rpcs_) {
         delete rpcs_;
         rpcs_ = nullptr;
-    }
-    if (rpcsSocket_) {
-        delete rpcsSocket_;
-        rpcsSocket_ = nullptr;
     }
 }
 

--- a/lib/psion.h
+++ b/lib/psion.h
@@ -61,7 +61,6 @@ public:
 
 private:
 
-    TCPSocket* rpcsSocket_;
     RPCS* rpcs_;
     RFSV* rfsv_;
 

--- a/lib/rclip.cc
+++ b/lib/rclip.cc
@@ -2,6 +2,7 @@
  * This file is part of plptools.
  *
  *  Copyright (C) 1999-2001 Fritz Elfert <felfert@to.com>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,70 +21,77 @@
 #include "config.h"
 
 #include "rclip.h"
-#include "bufferstore.h"
-#include "tcpsocket.h"
+
 #include "bufferarray.h"
+#include "bufferstore.h"
 #include "Enum.h"
+#include "tcpsocket.h"
 
 #include <stdlib.h>
 #include <time.h>
 
-rclip::rclip(TCPSocket *_skt)
-{
-    skt = _skt;
+rclip* rclip::connect(const std::string &host, int port, Enum<ConnectionError> *error) {
+
+    if (error) {
+        *error = FACERR_NONE;
+    }
+
+    auto socket = std::make_unique<TCPSocket>();
+    if (!socket->connect(host.c_str(), port)) {
+        if (error) {
+            *error = FACERR_CONNECTION_FAILURE;
+        }
+        return nullptr;
+    }
+
+    return new rclip(std::move(socket));
+}
+
+rclip::rclip(std::unique_ptr<TCPSocket> socket) {
+    socket_ = std::move(socket);
     reset();
 }
 
-rclip::~rclip()
-{
-    skt->closeSocket();
+rclip::~rclip() {
+    socket_->closeSocket();
 }
 
 //
 // public common API
 //
-void rclip::
-reconnect(void)
-{
-    //skt->closeSocket();
-    skt->reconnect();
+void rclip::reconnect(void) {
+    socket_->reconnect();
     reset();
 }
 
-void rclip::
-reset(void)
-{
+void rclip::reset(void) {
     BufferStore a;
     status = RFSV::E_PSI_FILE_DISC;
     a.addStringT(getConnectName());
-    if (skt->sendBufferStore(a)) {
-        if (skt->getBufferStore(a) == 1) {
-            if (!strcmp(a.getString(0), "NAK"))
+    if (socket_->sendBufferStore(a)) {
+        if (socket_->getBufferStore(a) == 1) {
+            if (!strcmp(a.getString(0), "NAK")) {
                 status = RFSV::E_PSI_GEN_NSUP;
-            if (!strcmp(a.getString(0), "Ok"))
+            }
+            if (!strcmp(a.getString(0), "Ok")) {
                 status = RFSV::E_PSI_GEN_NONE;
+            }
         }
     }
 }
 
-Enum<RFSV::errs> rclip::
-getStatus(void)
-{
+Enum<RFSV::errs> rclip::getStatus(void) {
     return status;
 }
 
-const char *rclip::
-getConnectName(void)
-{
+const char *rclip::getConnectName(void) {
     return "CLIPSVR.RSY";
 }
 
 //
 // protected internals
 //
-bool rclip::
-sendCommand(enum commands cc)
-{
+bool rclip::sendCommand(enum commands cc) {
     if (status == RFSV::E_PSI_FILE_DISC) {
         reconnect();
         if (status == RFSV::E_PSI_FILE_DISC)
@@ -102,97 +110,97 @@ sendCommand(enum commands cc)
         case RCLIP_NOTIFY:
             a.addByte(0);
     }
-    result = skt->sendBufferStore(a);
+    result = socket_->sendBufferStore(a);
     if (!result) {
         reconnect();
-        result = skt->sendBufferStore(a);
+        result = socket_->sendBufferStore(a);
         if (!result)
             status = RFSV::E_PSI_FILE_DISC;
     }
     return result;
 }
 
-Enum<RFSV::errs> rclip::
-sendListen() {
-    if (sendCommand(RCLIP_LISTEN))
+Enum<RFSV::errs> rclip::sendListen() {
+    if (sendCommand(RCLIP_LISTEN)) {
         return RFSV::E_PSI_GEN_NONE;
-    else
+    } else {
         return status;
+    }
 }
 
-Enum<RFSV::errs> rclip::
-checkNotify() {
+Enum<RFSV::errs> rclip::checkNotify() {
     Enum<RFSV::errs> ret;
     BufferStore a;
 
-    int r = skt->getBufferStore(a, false);
+    int r = socket_->getBufferStore(a, false);
     if (r < 0) {
         ret = status = RFSV::E_PSI_FILE_DISC;
     } else {
-        if (r == 0)
+        if (r == 0) {
             ret = RFSV::E_PSI_FILE_EOF;
-        else {
-            if ((a.getLen() != 1) || (a.getByte(0) != 0))
+        } else {
+            if ((a.getLen() != 1) || (a.getByte(0) != 0)) {
                 ret = RFSV::E_PSI_GEN_FAIL;
+            }
         }
     }
     return ret;
 }
 
-Enum<RFSV::errs> rclip::
-waitNotify() {
+Enum<RFSV::errs> rclip::waitNotify() {
     Enum<RFSV::errs> ret;
 
     BufferStore a;
     sendCommand(RCLIP_LISTEN);
     if ((ret = getResponse(a)) == RFSV::E_PSI_GEN_NONE) {
-        if ((a.getLen() != 1) || (a.getByte(0) != 0))
+        if ((a.getLen() != 1) || (a.getByte(0) != 0)) {
             ret = RFSV::E_PSI_GEN_FAIL;
+        }
     }
     return ret;
 }
 
-Enum<RFSV::errs> rclip::
-notify() {
+Enum<RFSV::errs> rclip::notify() {
     Enum<RFSV::errs> ret;
     BufferStore a;
 
     sendCommand(RCLIP_NOTIFY);
     if ((ret = getResponse(a)) == RFSV::E_PSI_GEN_NONE) {
-        if ((a.getLen() != 1) || (a.getByte(0) != RCLIP_NOTIFY))
+        if ((a.getLen() != 1) || (a.getByte(0) != RCLIP_NOTIFY)) {
             ret = RFSV::E_PSI_GEN_FAIL;
+        }
     }
     return ret;
 }
 
-Enum<RFSV::errs> rclip::
-initClipbd() {
+Enum<RFSV::errs> rclip::initClipbd() {
     Enum<RFSV::errs> ret;
     BufferStore a;
 
-    if (status != RFSV::E_PSI_GEN_NONE)
+    if (status != RFSV::E_PSI_GEN_NONE) {
         return status;
+    }
 
     sendCommand(RCLIP_INIT);
     if ((ret = getResponse(a)) == RFSV::E_PSI_GEN_NONE) {
-        if ((a.getLen() != 3) || (a.getByte(0) != RCLIP_INIT) ||
-            (a.getWord(1) != 0x100))
+        if ((a.getLen() != 3) || (a.getByte(0) != RCLIP_INIT) || (a.getWord(1) != 0x100)) {
             ret = RFSV::E_PSI_GEN_FAIL;
+        }
     }
     return ret;
 }
 
-Enum<RFSV::errs> rclip::
-getResponse(BufferStore & data)
-{
+Enum<RFSV::errs> rclip::getResponse(BufferStore & data) {
     Enum<RFSV::errs> ret = RFSV::E_PSI_GEN_NONE;
 
-    if (status == RFSV::E_PSI_GEN_NSUP)
+    if (status == RFSV::E_PSI_GEN_NSUP) {
         return status;
+    }
 
-    if (skt->getBufferStore(data) == 1)
+    if (socket_->getBufferStore(data) == 1) {
         return ret;
-    else
+    } else {
         status = RFSV::E_PSI_FILE_DISC;
+    }
     return status;
 }

--- a/lib/rclip.h
+++ b/lib/rclip.h
@@ -20,8 +20,10 @@
 #ifndef _RCLIP_H_
 #define _RCLIP_H_
 
+#include "connectionerror.h"
 #include "rfsv.h"
 #include "Enum.h"
+#include <memory>
 
 class TCPSocket;
 class BufferStore;
@@ -42,12 +44,15 @@ class BufferArray;
  */
 class rclip {
 public:
+
+    static rclip *connect(const std::string &host, int port, Enum<ConnectionError> *error = nullptr);
+
     /**
     * Constructs a new rclip object.
     *
-    * @param skt The socket to be used by this object.
+    * @param socket The socket to be used by this object.
     */
-    rclip(TCPSocket *skt);
+    rclip(std::unique_ptr<TCPSocket> socket);
 
     /**
     * Destructor.
@@ -147,7 +152,7 @@ protected:
     * The socket, used for communication
     * with ncpd.
     */
-    TCPSocket *skt;
+    std::unique_ptr<TCPSocket> socket_;
 
     /**
     * The current status of the connection.

--- a/lib/rfsvfactory.cc
+++ b/lib/rfsvfactory.cc
@@ -46,8 +46,7 @@ RFSVFactory::RFSVFactory(const std::string &host, int port)
 : host_(host)
 , port_(port) {}
 
-RFSVFactory::~RFSVFactory() {
-}
+RFSVFactory::~RFSVFactory() {}
 
 RFSV* RFSVFactory::create(bool reconnect, Enum<errs> *error) {
 
@@ -68,9 +67,9 @@ RFSV* RFSVFactory::create(bool reconnect, Enum<errs> *error) {
     // saw, so we can instantiate the correct RFSV protocol handler for the caller. We announce ourselves to the NCP
     // daemon, and the relevant RFSV module will also announce itself.
 
-    BufferStore a;
-    a.addStringT("NCP$INFO");
-    if (!socket->sendBufferStore(a)) {
+    BufferStore bufferStore;
+    bufferStore.addStringT("NCP$INFO");
+    if (!socket->sendBufferStore(bufferStore)) {
         if (!reconnect) {
             if (error) {
                 *error = FACERR_COULD_NOT_SEND;
@@ -84,14 +83,14 @@ RFSV* RFSVFactory::create(bool reconnect, Enum<errs> *error) {
         }
         return NULL;
     }
-    if (socket->getBufferStore(a) == 1) {
-        if (a.getLen() > 8 && !strncmp(a.getString(), "Series 3", 8)) {
+    if (socket->getBufferStore(bufferStore) == 1) {
+        if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 3", 8)) {
             return new RFSV16(std::move(socket));
         }
-        else if (a.getLen() > 8 && !strncmp(a.getString(), "Series 5", 8)) {
+        else if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 5", 8)) {
             return new RFSV32(std::move(socket));
         }
-        if ((a.getLen() > 8) && !strncmp(a.getString(), "No Psion", 8)) {
+        if ((bufferStore.getLen() > 8) && !strncmp(bufferStore.getString(), "No Psion", 8)) {
             socket->closeSocket();
             socket->reconnect();
             if (error) {
@@ -103,10 +102,11 @@ RFSV* RFSVFactory::create(bool reconnect, Enum<errs> *error) {
         if (error) {
             *error = FACERR_PROTVERSION;
         }
-    } else
+    } else {
         if (error) {
             *error = FACERR_NORESPONSE;
         }
+    }
 
     return NULL;
 }

--- a/lib/rfsvfactory.cc
+++ b/lib/rfsvfactory.cc
@@ -2,6 +2,7 @@
  * This file is part of plptools.
  *
  *  Copyright (C) 1999 Matt J. Gumbley <matt@gumbley.demon.co.uk>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/lib/rfsvfactory.cc
+++ b/lib/rfsvfactory.cc
@@ -32,23 +32,13 @@
 
 using namespace std;
 
-ENUM_DEFINITION_BEGIN(RFSVFactory::errs, RFSVFactory::FACERR_NONE)
-    stringRep.add(RFSVFactory::FACERR_NONE,               N_("no error"));
-    stringRep.add(RFSVFactory::FACERR_COULD_NOT_SEND,     N_("could not send version request"));
-    stringRep.add(RFSVFactory::FACERR_AGAIN,              N_("try again"));
-    stringRep.add(RFSVFactory::FACERR_NOPSION,            N_("no EPOC device connected"));
-    stringRep.add(RFSVFactory::FACERR_PROTVERSION,        N_("wrong protocol version"));
-    stringRep.add(RFSVFactory::FACERR_NORESPONSE,         N_("no response from ncpd"));
-    stringRep.add(RFSVFactory::FACERR_CONNECTION_FAILURE, N_("could not connect to ncpd"));
-ENUM_DEFINITION_END(RFSVFactory::errs)
-
 RFSVFactory::RFSVFactory(const std::string &host, int port)
 : host_(host)
 , port_(port) {}
 
 RFSVFactory::~RFSVFactory() {}
 
-RFSV* RFSVFactory::create(bool reconnect, Enum<errs> *error) {
+RFSV* RFSVFactory::create(bool reconnect, Enum<ConnectionError> *error) {
 
     if (error) {
         *error = FACERR_NONE;

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -57,7 +57,7 @@ public:
     /**
      * Delete the RFSVFactory, cleaning up any resources.
      */
-    virtual ~RFSVFactory();
+    ~RFSVFactory();
 
     /**
     * Creates a new @ref RFSV instance.
@@ -67,7 +67,7 @@ public:
     *
     * @returns A pointer to a newly created @ref RFSV instance or NULL on failure.
     */
-    virtual RFSV* create(bool, Enum<errs> *error = nullptr);
+    RFSV* create(bool, Enum<errs> *error = nullptr);
 
 private:
     std::string host_;

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -21,8 +21,10 @@
  */
 #pragma once
 
-#include "rfsv.h"
 #include <cstddef>
+
+#include "connectionerror.h"
+#include "rfsv.h"
 
 class TCPSocket;
 
@@ -33,18 +35,6 @@ class TCPSocket;
 class RFSVFactory final {
 
 public:
-    /**
-    * The known errors which can happen during @ref create .
-    */
-    enum errs {
-        FACERR_NONE = 0,
-        FACERR_COULD_NOT_SEND = 1,
-        FACERR_AGAIN = 2,
-        FACERR_NOPSION = 3,
-        FACERR_PROTVERSION = 4,
-        FACERR_NORESPONSE = 5,
-        FACERR_CONNECTION_FAILURE = 6,
-    };
 
     /**
     * Constructs a RFSVFactory.
@@ -67,7 +57,7 @@ public:
     *
     * @returns A pointer to a newly created @ref RFSV instance or NULL on failure.
     */
-    RFSV* create(bool, Enum<errs> *error = nullptr);
+    RFSV* create(bool, Enum<ConnectionError> *error = nullptr);
 
 private:
     std::string host_;

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -30,7 +30,7 @@ class TCPSocket;
  * A factory for automatically instantiating the correct
  * @ref RFSV protocol variant depending on the connected Psion.
  */
-class RFSVFactory {
+class RFSVFactory final {
 
 public:
     /**

--- a/lib/rfsvfactory.h
+++ b/lib/rfsvfactory.h
@@ -4,6 +4,7 @@
  *  Copyright (C) 1999 Philip Proudman <philip.proudman@btinternet.com>
  *  Copyright (C) 1999 Matt J. Gumbley <matt@gumbley.demon.co.uk>
  *  Copyright (C) 1999-2001 Fritz Elfert <felfert@to.com>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/lib/rpcs.cc
+++ b/lib/rpcs.cc
@@ -87,14 +87,14 @@ ENUM_DEFINITION_BEGIN(RPCS::languages, RPCS::PSI_LANG_TEST)
 ENUM_DEFINITION_END(RPCS::languages)
 
 RPCS::~RPCS() {
-    skt->closeSocket();
+    socket_->closeSocket();
 }
 
 //
 // public common API
 //
 void RPCS::reconnect(void) {
-    skt->reconnect();
+    socket_->reconnect();
     reset();
 }
 
@@ -103,8 +103,8 @@ void RPCS::reset(void) {
     mtCacheS5mx = 0;
     status = RFSV::E_PSI_FILE_DISC;
     a.addStringT(getConnectName());
-    if (skt->sendBufferStore(a)) {
-        if (skt->getBufferStore(a) == 1) {
+    if (socket_->sendBufferStore(a)) {
+        if (socket_->getBufferStore(a) == 1) {
             if (!strcmp(a.getString(0), "Ok")) {
                 status = RFSV::E_PSI_GEN_NONE;
             }
@@ -134,10 +134,10 @@ bool RPCS::sendCommand(enum commands cc, BufferStore & data) {
     BufferStore a;
     a.addByte(cc);
     a.addBuff(data);
-    result = skt->sendBufferStore(a);
+    result = socket_->sendBufferStore(a);
     if (!result) {
         reconnect();
-        result = skt->sendBufferStore(a);
+        result = socket_->sendBufferStore(a);
         if (!result) {
             status = RFSV::E_PSI_FILE_DISC;
         }
@@ -147,7 +147,7 @@ bool RPCS::sendCommand(enum commands cc, BufferStore & data) {
 
 Enum<RFSV::errs> RPCS::getResponse(BufferStore & data, bool statusIsFirstByte) {
     Enum<RFSV::errs> ret;
-    if (skt->getBufferStore(data) == 1) {
+    if (socket_->getBufferStore(data) == 1) {
         if (statusIsFirstByte) {
             ret = (enum RFSV::errs)((char)data.getByte(0));
             data.discardFirstBytes(1);

--- a/lib/rpcs.h
+++ b/lib/rpcs.h
@@ -25,6 +25,7 @@
 #include "rfsv.h"
 #include "Enum.h"
 
+#include <memory>
 #include <vector>
 
 class TCPSocket;
@@ -414,10 +415,9 @@ public:
 
 protected:
     /**
-    * The socket, used for communication
-    * with ncpd.
+    * The socket, used for communication with ncpd.
     */
-    TCPSocket *skt;
+    std::unique_ptr<TCPSocket> socket_;
 
     /**
     * The current status of the connection.

--- a/lib/rpcs16.cc
+++ b/lib/rpcs16.cc
@@ -25,14 +25,15 @@
 #include "bufferarray.h"
 #include "tcpsocket.h"
 
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 
 using namespace std;
 
-RPCS16::RPCS16(TCPSocket *_skt) {
-    skt = _skt;
+RPCS16::RPCS16(std::unique_ptr<TCPSocket> socket) {
+    socket_ = std::move(socket);
     mtCacheS5mx = 0;
     reset();
 }

--- a/lib/rpcs16.h
+++ b/lib/rpcs16.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "rpcs.h"
+#include <memory>
 
 class TCPSocket;
 class BufferStore;
@@ -42,5 +43,5 @@ class RPCS16 : public RPCS {
 
 
  private:
-    RPCS16(TCPSocket *);
+    RPCS16(std::unique_ptr<TCPSocket> socket);
 };

--- a/lib/rpcs32.cc
+++ b/lib/rpcs32.cc
@@ -26,14 +26,15 @@
 
 #include <iostream>
 
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 
 using namespace std;
 
-RPCS32::RPCS32(TCPSocket * _skt) {
-    skt = _skt;
+RPCS32::RPCS32(std::unique_ptr<TCPSocket> socket) {
+    socket_ = std::move(socket);
     mtCacheS5mx = 0;
     reset();
 }

--- a/lib/rpcs32.h
+++ b/lib/rpcs32.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "rpcs.h"
+#include <memory>
 
 class TCPSocket;
 class RPCSFactory;
@@ -58,5 +59,5 @@ protected:
     Enum<RFSV::errs> configOpen(uint16_t &, uint32_t);
 
  private:
-    RPCS32(TCPSocket *);
+    RPCS32(std::unique_ptr<TCPSocket> socket);
 };

--- a/lib/rpcsfactory.cc
+++ b/lib/rpcsfactory.cc
@@ -38,55 +38,73 @@ ENUM_DEFINITION_BEGIN(RPCSFactory::errs, RPCSFactory::FACERR_NONE)
     stringRep.add(RPCSFactory::FACERR_NORESPONSE,     N_("no response from ncpd"));
 ENUM_DEFINITION_END(RPCSFactory::errs)
 
-RPCSFactory::RPCSFactory(TCPSocket *_skt) {
-    err = FACERR_NONE;
-    skt = _skt;
-}
+RPCSFactory::RPCSFactory(const std::string &host, int port)
+: host_(host)
+, port_(port) {}
 
-RPCSFactory::~RPCSFactory() {
+RPCSFactory::~RPCSFactory() {}
 
-}
+RPCS *RPCSFactory::create(bool reconnect, Enum<errs> *error) {
 
-RPCS *RPCSFactory::create(bool reconnect) {
-    // skt is connected to the ncp daemon, which will have (hopefully) seen
-    // an INFO exchange, where the protocol version of the remote Psion was
-    // sent, and noted. We have to ask the ncp daemon which protocol it saw,
-    // so we can instantiate the correct RPCS protocol handler for the
-    // caller. We announce ourselves to the NCP daemon, and the relevant
-    // RPCS module will also announce itself.
-
-    BufferStore a;
-
-    err = FACERR_NONE;
-    a.addStringT("NCP$INFO");
-    if (!skt->sendBufferStore(a)) {
-        if (!reconnect)
-            err = FACERR_COULD_NOT_SEND;
-        else {
-            skt->closeSocket();
-            skt->reconnect();
-            err = FACERR_AGAIN;
-        }
-        return NULL;
+    if (error) {
+        *error = FACERR_NONE;
     }
-    if (skt->getBufferStore(a) == 1) {
-        if (a.getLen() > 8 && !strncmp(a.getString(), "Series 3", 8)) {
-            return new RPCS16(skt);
+
+    auto socket = std::make_unique<TCPSocket>();
+    if (!socket->connect(host_.c_str(), port_)) {
+        if (error) {
+            *error = FACERR_CONNECTION_FAILURE;
         }
-        else if (a.getLen() > 8 && !strncmp(a.getString(), "Series 5", 8)) {
-            return new RPCS32(skt);
+        return nullptr;
+    }
+
+    // At this point the socket is connected to the ncp daemon, which will have (hopefully) seen an INFO exchange, where
+    // the protocol version of the remote Psion was sent, and noted. We have to ask the ncp daemon which protocol it
+    // saw, so we can instantiate the correct RPCS protocol handler for the caller. We announce ourselves to the NCP
+    // daemon, and the relevant RPCS module will also announce itself.
+
+    BufferStore bufferStore;
+
+    bufferStore.addStringT("NCP$INFO");
+    if (!socket->sendBufferStore(bufferStore)) {
+        if (!reconnect) {
+            if (error) {
+                *error = FACERR_COULD_NOT_SEND;
+            }
+        } else {
+            socket->closeSocket();
+            socket->reconnect();
+            if (error) {
+                *error = FACERR_AGAIN;
+            }
         }
-        if ((a.getLen() > 8) && !strncmp(a.getString(), "No Psion", 8)) {
-            skt->closeSocket();
-            skt->reconnect();
-            err = FACERR_NOPSION;
-            return NULL;
+        return nullptr;
+    }
+    if (socket->getBufferStore(bufferStore) == 1) {
+        if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 3", 8)) {
+            return new RPCS16(std::move(socket));
+        }
+        else if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 5", 8)) {
+            return new RPCS32(std::move(socket));
+        }
+        if ((bufferStore.getLen() > 8) && !strncmp(bufferStore.getString(), "No Psion", 8)) {
+            socket->closeSocket();
+            socket->reconnect();
+            if (error) {
+                *error = FACERR_NOPSION;
+            }
+            return nullptr;
         }
         // Invalid protocol version
-        err = FACERR_PROTVERSION;
-    } else
-        err = FACERR_NORESPONSE;
+        if (error) {
+            *error = FACERR_PROTVERSION;
+        }
+    } else {
+        if (error) {
+            *error = FACERR_NORESPONSE;
+        }
+    }
 
     // No message returned.
-    return NULL;
+    return nullptr;
 }

--- a/lib/rpcsfactory.cc
+++ b/lib/rpcsfactory.cc
@@ -2,6 +2,7 @@
  * This file is part of plptools.
  *
  *  Copyright (C) 2000-2001 Fritz Elfert <felfert@to.com>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/lib/rpcsfactory.cc
+++ b/lib/rpcsfactory.cc
@@ -29,22 +29,13 @@
 #include <stdlib.h>
 #include <time.h>
 
-ENUM_DEFINITION_BEGIN(RPCSFactory::errs, RPCSFactory::FACERR_NONE)
-    stringRep.add(RPCSFactory::FACERR_NONE,           N_("no error"));
-    stringRep.add(RPCSFactory::FACERR_COULD_NOT_SEND, N_("could not send version request"));
-    stringRep.add(RPCSFactory::FACERR_AGAIN,          N_("try again"));
-    stringRep.add(RPCSFactory::FACERR_NOPSION,        N_("no EPOC device connected"));
-    stringRep.add(RPCSFactory::FACERR_PROTVERSION,    N_("wrong protocol version"));
-    stringRep.add(RPCSFactory::FACERR_NORESPONSE,     N_("no response from ncpd"));
-ENUM_DEFINITION_END(RPCSFactory::errs)
-
 RPCSFactory::RPCSFactory(const std::string &host, int port)
 : host_(host)
 , port_(port) {}
 
 RPCSFactory::~RPCSFactory() {}
 
-RPCS *RPCSFactory::create(bool reconnect, Enum<errs> *error) {
+RPCS *RPCSFactory::create(bool reconnect, Enum<ConnectionError> *error) {
 
     if (error) {
         *error = FACERR_NONE;

--- a/lib/rpcsfactory.h
+++ b/lib/rpcsfactory.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include "connectionerror.h"
 #include "rpcs.h"
 
 class TCPSocket;
@@ -30,19 +31,6 @@ class TCPSocket;
  */
 class RPCSFactory final {
  public:
-
-    /**
-    * The known errors which can happen during @ref create .
-    */
-    enum errs {
-        FACERR_NONE = 0,
-        FACERR_COULD_NOT_SEND = 1,
-        FACERR_AGAIN = 2,
-        FACERR_NOPSION = 3,
-        FACERR_PROTVERSION = 4,
-        FACERR_NORESPONSE = 5,
-        FACERR_CONNECTION_FAILURE = 6,
-    };
 
     /**
     * Constructs a RPCSFactory.
@@ -65,7 +53,7 @@ class RPCSFactory final {
     *
     * @returns A pointer to a newly created @ref RPCS instance or NULL on failure.
     */
-    RPCS* create(bool, Enum<errs> *error = nullptr);
+    RPCS* create(bool, Enum<ConnectionError> *error = nullptr);
 
  private:
     std::string host_;

--- a/lib/rpcsfactory.h
+++ b/lib/rpcsfactory.h
@@ -28,7 +28,7 @@ class TCPSocket;
  * A factory for automatically instantiating the correct protocol
  * variant depending on the connected Psion.
  */
-class RPCSFactory {
+class RPCSFactory final {
  public:
 
     /**

--- a/lib/rpcsfactory.h
+++ b/lib/rpcsfactory.h
@@ -3,6 +3,7 @@
  *
  *  Copyright (C) 1999 Philip Proudman <philip.proudman@btinternet.com>
  *  Copyright (C) 1999-2001 Fritz Elfert <felfert@to.com>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/lib/rpcsfactory.h
+++ b/lib/rpcsfactory.h
@@ -40,16 +40,17 @@ class RPCSFactory {
         FACERR_AGAIN = 2,
         FACERR_NOPSION = 3,
         FACERR_PROTVERSION = 4,
-        FACERR_NORESPONSE = 5
+        FACERR_NORESPONSE = 5,
+        FACERR_CONNECTION_FAILURE = 6,
     };
 
     /**
     * Constructs a RPCSFactory.
     *
-    * @param skt The socket to be used for connecting
-    * to the ncpd daemon.
+    * @param host The host be used for connecting to the ncpd daemon.
+    * @param port The port be used for connecting to the ncpd daemon.
     */
-    RPCSFactory(TCPSocket *skt);
+    RPCSFactory(const std::string &host, int port);
 
     /**
      * Delete the RPCSFactory, cleaning up any resources.
@@ -59,27 +60,14 @@ class RPCSFactory {
     /**
     * Creates a new RPCS instance.
     *
-    * @param reconnect Set to true, if automatic reconnect
-    * should be performed on failure.
+    * @param reconnect Set to true, if automatic reconnect should be performed on failure.
+    * @param error Out parameter; set to the error on failure if non-NULL.
     *
-    * @returns A pointer to a newly created RPCS instance or
-    * NULL on failure.
+    * @returns A pointer to a newly created @ref RPCS instance or NULL on failure.
     */
-    virtual RPCS *create(bool reconnect);
-
-    /**
-    * Retrieve an error code.
-    *
-    * @returns The error code, in case @ref create has
-    * failed, 0 otherwise.
-    */
-    virtual Enum<errs> getError() { return err; }
+    virtual RPCS* create(bool, Enum<errs> *error = nullptr);
 
  private:
-    /**
-    * The socket to be used for connecting to the
-    * ncpd daemon.
-    */
-    TCPSocket *skt;
-    Enum<errs> err;
+    std::string host_;
+    int port_;
 };

--- a/lib/rpcsfactory.h
+++ b/lib/rpcsfactory.h
@@ -55,7 +55,7 @@ class RPCSFactory {
     /**
      * Delete the RPCSFactory, cleaning up any resources.
      */
-    virtual ~RPCSFactory();
+    ~RPCSFactory();
 
     /**
     * Creates a new RPCS instance.
@@ -65,7 +65,7 @@ class RPCSFactory {
     *
     * @returns A pointer to a newly created @ref RPCS instance or NULL on failure.
     */
-    virtual RPCS* create(bool, Enum<errs> *error = nullptr);
+    RPCS* create(bool, Enum<errs> *error = nullptr);
 
  private:
     std::string host_;

--- a/plpftp/ftp.cc
+++ b/plpftp/ftp.cc
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <drive.h>
 #include <Enum.h>
+#include <memory>
 #include <pathutils.h>
 #include <plpintl.h>
 #include <rclip.h>
@@ -309,11 +310,7 @@ static int startPrograms(RPCS & r, RFSV &a, const char *file) {
     return 0;
 }
 
-bool FTP::checkClipConnection(RFSV &a, rclip & rc, TCPSocket &) {
-    if (canClip == false) {
-        return false;
-    }
-
+bool FTP::checkClipConnection(RFSV &a, rclip & rc) {
     if (a.getProtocolVersion() == 3) {
         cerr << _("Clipboard protocol not supported by Psion Series 3.") << endl;
         return false;
@@ -383,7 +380,7 @@ static char *slurp(FILE *fp, size_t *final_len) {
     return get_upto(fp, "", final_len);
 }
 
-int FTP::putClipText(RPCS &, RFSV &a, rclip & rc, TCPSocket & rclipSocket, const char *file) {
+int FTP::putClipText(RPCS &, RFSV &a, rclip & rc, const char *file) {
     Enum<RFSV::errs> res;
     uint32_t fh;
     uint32_t l;
@@ -392,7 +389,7 @@ int FTP::putClipText(RPCS &, RFSV &a, rclip & rc, TCPSocket & rclipSocket, const
     char *data;
     FILE *fp;
 
-    if (!checkClipConnection(a, rc, rclipSocket)) {
+    if (!checkClipConnection(a, rc)) {
         return 1;
     }
 
@@ -433,7 +430,7 @@ int FTP::putClipText(RPCS &, RFSV &a, rclip & rc, TCPSocket & rclipSocket, const
     return 0;
 }
 
-int FTP::getClipData(RPCS &, RFSV &a, rclip &, TCPSocket &, const char *file) {
+int FTP::getClipData(RPCS &, RFSV &a, rclip &, const char *file) {
     Enum<RFSV::errs> res;
     PlpDirent de;
     uint32_t fh;
@@ -534,7 +531,7 @@ static char *epoc_dir_from(const char *path) {
     return f1;
 }
 
-int FTP::session(RFSV &rfsv, RPCS &rpcs, rclip &rc, TCPSocket &rclipSocket, vector<char *> argv) {
+int FTP::session(RFSV &rfsv, RPCS &rpcs, rclip &clipboard, vector<char *> argv) {
     Enum<RFSV::errs> res;
     bool prompt = true;
     bool hash = false;
@@ -1188,13 +1185,13 @@ int FTP::session(RFSV &rfsv, RPCS &rpcs, rclip &rc, TCPSocket &rclipSocket, vect
             continue;
         }
         if (!strcmp(argv[0], "putclip") && (argc == 2)) {
-            if (putClipText(rpcs, rfsv, rc, rclipSocket, argv[1])) {
+            if (putClipText(rpcs, rfsv, clipboard, argv[1])) {
                 cerr << _("Error setting clipboard") << endl;
             }
             continue;
         }
         if (!strcmp(argv[0], "getclip") && (argc == 2)) {
-            if (getClipData(rpcs, rfsv, rc, rclipSocket, argv[1])) {
+            if (getClipData(rpcs, rfsv, clipboard, argv[1])) {
                 cerr << _("Error getting clipboard") << endl;
             }
             continue;

--- a/plpftp/ftp.cc
+++ b/plpftp/ftp.cc
@@ -310,7 +310,7 @@ static int startPrograms(RPCS & r, RFSV &a, const char *file) {
     return 0;
 }
 
-bool FTP::checkClipConnection(RFSV &a, rclip & rc) {
+bool FTP::checkClipConnection(RFSV &a, rclip &rc) {
     if (a.getProtocolVersion() == 3) {
         cerr << _("Clipboard protocol not supported by Psion Series 3.") << endl;
         return false;
@@ -380,7 +380,7 @@ static char *slurp(FILE *fp, size_t *final_len) {
     return get_upto(fp, "", final_len);
 }
 
-int FTP::putClipText(RPCS &, RFSV &a, rclip & rc, const char *file) {
+int FTP::putClipText(RFSV &a, rclip & rc, const char *file) {
     Enum<RFSV::errs> res;
     uint32_t fh;
     uint32_t l;
@@ -430,11 +430,15 @@ int FTP::putClipText(RPCS &, RFSV &a, rclip & rc, const char *file) {
     return 0;
 }
 
-int FTP::getClipData(RPCS &, RFSV &a, rclip &, const char *file) {
+int FTP::getClipData(RFSV &a, rclip &rc, const char *file) {
     Enum<RFSV::errs> res;
     PlpDirent de;
     uint32_t fh;
     string clipText;
+
+    if (!checkClipConnection(a, rc)) {
+        return 1;
+    }
 
     res = a.fgeteattr(CLIPFILE, de);
     if (res == RFSV::E_PSI_GEN_NONE) {
@@ -1185,13 +1189,13 @@ int FTP::session(RFSV &rfsv, RPCS &rpcs, rclip &clipboard, vector<char *> argv) 
             continue;
         }
         if (!strcmp(argv[0], "putclip") && (argc == 2)) {
-            if (putClipText(rpcs, rfsv, clipboard, argv[1])) {
+            if (putClipText(rfsv, clipboard, argv[1])) {
                 cerr << _("Error setting clipboard") << endl;
             }
             continue;
         }
         if (!strcmp(argv[0], "getclip") && (argc == 2)) {
-            if (getClipData(rpcs, rfsv, clipboard, argv[1])) {
+            if (getClipData(rfsv, clipboard, argv[1])) {
                 cerr << _("Error getting clipboard") << endl;
             }
             continue;

--- a/plpftp/ftp.h
+++ b/plpftp/ftp.h
@@ -23,6 +23,7 @@
 
 #include "config.h"
 
+#include <memory>
 #include <vector>
 
 #include "rfsv.h"
@@ -36,15 +37,14 @@ class FTP {
 public:
     FTP();
     ~FTP();
-    int session(RFSV &a, RPCS &r, rclip &rc, TCPSocket &rclipSocket, std::vector<char *> argv);
-    bool canClip;
+    int session(RFSV &rfsv, RPCS &rpcs, rclip &clipboard, std::vector<char *> argv);
 
 private:
     std::vector<char *> getCommand();
     void initReadline(void);
-    int putClipText(RPCS &r, RFSV &a, rclip &rc, TCPSocket &rclipSocket, const char *data);
-    int getClipData(RPCS &r, RFSV &a, rclip &rc, TCPSocket &rclipSocket, const char *file);
-    bool checkClipConnection(RFSV &a, rclip &rc, TCPSocket &rclipSocket);
+    int putClipText(RPCS &r, RFSV &a, rclip &rc, const char *data);
+    int getClipData(RPCS &r, RFSV &a, rclip &rc, const char *file);
+    bool checkClipConnection(RFSV &a, rclip &rc);
 
     // utilities
     void resetUnixWd();

--- a/plpftp/ftp.h
+++ b/plpftp/ftp.h
@@ -42,8 +42,8 @@ public:
 private:
     std::vector<char *> getCommand();
     void initReadline(void);
-    int putClipText(RPCS &r, RFSV &a, rclip &rc, const char *data);
-    int getClipData(RPCS &r, RFSV &a, rclip &rc, const char *file);
+    int putClipText(RFSV &a, rclip &rc, const char *data);
+    int getClipData(RFSV &a, rclip &rc, const char *file);
     bool checkClipConnection(RFSV &a, rclip &rc);
 
     // utilities

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -130,12 +130,12 @@ int main(int argc, char **argv) {
     auto rpcsFactory = std::make_unique<RPCSFactory>(host, sockNum);
 
     Enum<RFSVFactory::errs> error;
-    auto rfsv = rfsvFactory->create(false, &error);
-    auto rpcs = rpcsFactory->create(false);
+    auto rfsv = std::unique_ptr<RFSV>(rfsvFactory->create(false, &error));
+    auto rpcs = std::unique_ptr<RPCS>(rpcsFactory->create(false));
 
     rclip *rc;
     auto rclipSocket = new TCPSocket();
-    rclipSocket->connect(NULL, sockNum);
+    rclipSocket->connect(host.c_str(), sockNum);
     if (rclipSocket) {
         rc = new rclip(rclipSocket);
     }
@@ -144,8 +144,6 @@ int main(int argc, char **argv) {
     if ((rfsv != NULL) && (rpcs != NULL)) {
         vector<char *> args(argv + optind, argv + argc);
         status = f.session(*rfsv, *rpcs, *rc, *rclipSocket, args);
-        delete rpcs;
-        delete rfsv;
         if (rclipSocket) {
             delete rclipSocket;
         }

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -131,8 +131,12 @@ int main(int argc, char **argv) {
 
     Enum<ConnectionError> error;
     auto rfsv = std::unique_ptr<RFSV>(rfsvFactory->create(false, &error));
+    if (!rfsv) {
+        cerr << "plpftp: " << error << endl;
+        return EXIT_FAILURE;
+    }
     auto rpcs = std::unique_ptr<RPCS>(rpcsFactory->create(false, &error));
-    if (!rfsv || !rpcs) {
+    if (!rpcs) {
         cerr << "plpftp: " << error << endl;
         return EXIT_FAILURE;
     }

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -140,22 +140,11 @@ int main(int argc, char **argv) {
         cerr << "plpftp: " << error << endl;
         return EXIT_FAILURE;
     }
-
-    rclip *rc = nullptr;
-    auto rclipSocket = new TCPSocket();
-    rclipSocket->connect(host.c_str(), sockNum);
-    if (rclipSocket) {
-        rc = new rclip(rclipSocket);
+    auto clipboard = std::unique_ptr<rclip>(rclip::connect(host, sockNum, &error));
+    if (!clipboard) {
+        cerr << "plpftp: " << error << endl;
+        return EXIT_FAILURE;
     }
-    ftp.canClip = rclipSocket && rc ? true : false;
-
     vector<char *> args(argv + optind, argv + argc);
-    status = ftp.session(*rfsv, *rpcs, *rc, *rclipSocket, args);
-    if (rclipSocket) {
-        delete rclipSocket;
-    }
-    if (rc) {
-        delete rc;
-    }
-    return status;
+    return ftp.session(*rfsv, *rpcs, *clipboard, args);
 }

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -92,11 +92,6 @@ void ftpHeader() {
 }
 
 int main(int argc, char **argv) {
-    TCPSocket *skt2;
-    RFSV *a;
-    RPCS *r;
-    TCPSocket *rclipSocket;
-    rclip *rc;
     FTP f;
     string host = "127.0.0.1";
     int status = 0;
@@ -131,31 +126,29 @@ int main(int argc, char **argv) {
         ftpHeader();
     }
 
-    skt2 = new TCPSocket();
-    if (!skt2->connect(host.c_str(), sockNum)) {
-        cout << _("plpftp: could not connect to ncpd") << endl;
-        return 1;
-    }
-    auto rf = std::make_unique<RFSVFactory>(host, sockNum);
-    auto rp = std::make_unique<RPCSFactory>(skt2);
+    auto rfsvFactory = std::make_unique<RFSVFactory>(host, sockNum);
+    auto rpcsFactory = std::make_unique<RPCSFactory>(host, sockNum);
 
     Enum<RFSVFactory::errs> error;
-    a = rf->create(false, &error);
-    r = rp->create(false);
-    rclipSocket = new TCPSocket();
+    auto rfsv = rfsvFactory->create(false, &error);
+    auto rpcs = rpcsFactory->create(false);
+
+    rclip *rc;
+    auto rclipSocket = new TCPSocket();
     rclipSocket->connect(NULL, sockNum);
     if (rclipSocket) {
         rc = new rclip(rclipSocket);
     }
     f.canClip = rclipSocket && rc ? true : false;
-    if ((a != NULL) && (r != NULL)) {
+
+    if ((rfsv != NULL) && (rpcs != NULL)) {
         vector<char *> args(argv + optind, argv + argc);
-        status = f.session(*a, *r, *rc, *rclipSocket, args);
-        delete r;
-        delete a;
-        delete skt2;
-        if (rclipSocket)
+        status = f.session(*rfsv, *rpcs, *rc, *rclipSocket, args);
+        delete rpcs;
+        delete rfsv;
+        if (rclipSocket) {
             delete rclipSocket;
+        }
         if (rc) {
             delete rc;
         }

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -92,7 +92,7 @@ void ftpHeader() {
 }
 
 int main(int argc, char **argv) {
-    FTP f;
+    FTP ftp;
     string host = "127.0.0.1";
     int status = 0;
     int sockNum = cli_utils::lookup_default_port();
@@ -129,30 +129,29 @@ int main(int argc, char **argv) {
     auto rfsvFactory = std::make_unique<RFSVFactory>(host, sockNum);
     auto rpcsFactory = std::make_unique<RPCSFactory>(host, sockNum);
 
-    Enum<RFSVFactory::errs> error;
+    Enum<ConnectionError> error;
     auto rfsv = std::unique_ptr<RFSV>(rfsvFactory->create(false, &error));
-    auto rpcs = std::unique_ptr<RPCS>(rpcsFactory->create(false));
+    auto rpcs = std::unique_ptr<RPCS>(rpcsFactory->create(false, &error));
+    if (!rfsv || !rpcs) {
+        cerr << "plpftp: " << error << endl;
+        return EXIT_FAILURE;
+    }
 
-    rclip *rc;
+    rclip *rc = nullptr;
     auto rclipSocket = new TCPSocket();
     rclipSocket->connect(host.c_str(), sockNum);
     if (rclipSocket) {
         rc = new rclip(rclipSocket);
     }
-    f.canClip = rclipSocket && rc ? true : false;
+    ftp.canClip = rclipSocket && rc ? true : false;
 
-    if ((rfsv != NULL) && (rpcs != NULL)) {
-        vector<char *> args(argv + optind, argv + argc);
-        status = f.session(*rfsv, *rpcs, *rc, *rclipSocket, args);
-        if (rclipSocket) {
-            delete rclipSocket;
-        }
-        if (rc) {
-            delete rc;
-        }
-    } else {
-        cerr << "plpftp: " << error << endl;
-        status = 1;
+    vector<char *> args(argv + optind, argv + argc);
+    status = ftp.session(*rfsv, *rpcs, *rc, *rclipSocket, args);
+    if (rclipSocket) {
+        delete rclipSocket;
+    }
+    if (rc) {
+        delete rc;
     }
     return status;
 }

--- a/plpfuse/main.cc
+++ b/plpfuse/main.cc
@@ -381,7 +381,6 @@ int fuse(int argc, char *argv[])
 }
 
 int main(int argc, char**argv) {
-    TCPSocket *skt2;
     string host = "127.0.0.1";
     int sockNum = DPORT, i, c, oldoptind = 1;
 
@@ -418,14 +417,8 @@ int main(int argc, char**argv) {
             break;
     }
 
-    skt2 = new TCPSocket();
-    if (!skt2->connect(host.c_str(), sockNum)) {
-        cerr << _("plpfuse: could not connect to ncpd") << endl;
-        return 1;
-    }
-
     rf = new RFSVFactory(host.c_str(), sockNum);
-    rp = new RPCSFactory(skt2);
+    rp = new RPCSFactory(host.c_str(), sockNum);
     a = rf->create(true);
     r = rp->create(true);
     if (a != NULL && r != NULL)


### PR DESCRIPTION
Changes `RPCS` and `rclip` to own their `TCPSocket` instances and make them responsible for cleanup on deletion. Use `std::unique_ptr` to make the API and ownership model clear.

This change includes some small follow-up naming fixes in `RFSVFactory` and a non-trivial reworking of the clipboard logic in `FTP`—it turns out that, on inspection, the `rclip` instantiation should ever be able to fail (independently of `RFSVFactory::create` and `RPCSFactory::create`) and therefore `FTP::canClip` should never be false, so I've removed this variable. `FTP::session` was also never using `rclip`'s `TCPSocket` that we were passing in (even though it was passing it around), so I've removed that too.

This change reveals that the clipboard support in `plpftp` is incredibly murky and doesn't actually use the injected `rclip` instance at all. Since I assume we do want to use this in the future, I've not actually removed it from the code, but I've at least made the clipboard functionality guards consistent—put and get should now fail consistently on EPOC16. In the longer term (and as part of the work to actually fix clipboard handling) I believe we need to use `rclip` to notify EPOC32 devices that the on-device clipboard file has been changed.