### PR TITLE
refactor: Use a template to share ncpd client factory code

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -93,6 +93,7 @@ noinst_HEADERS = \
 	mp_serial.h \
 	ncp_log.h \
 	ncp.h \
+	ncpclient.h \
 	ncpsession.h \
 	ncpstatuscallback.h \
 	pathutils.h \

--- a/lib/ncpclient.h
+++ b/lib/ncpclient.h
@@ -1,0 +1,117 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (C) 1999 Philip Proudman <philip.proudman@btinternet.com>
+ *  Copyright (C) 1999-2002 Fritz Elfert <felfert@to.com>
+ *  Copyright (C) 2006-2025 Reuben Thomas <rrt@sc3d.org>
+ *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "config.h"
+
+#include <string>
+#include <vector>
+
+#include "connectionerror.h"
+#include "bufferstore.h"
+#include "Enum.h"
+#include "tcpsocket.h"
+
+class TCPClient;
+
+namespace ncp_client {
+
+/**
+* Create a new NCP client instance, selecting the appropriate subclass based on the device type reported by an
+* `NCP$INFO` query. Fails instantly if ncpd isn't running or accepting connections.
+*
+* @param host The host be used for connecting to the ncpd daemon.
+* @param port The port be used for connecting to the ncpd daemon.
+* @param waitForDevice Continue reconnecting to the ncpd daemon until a Psion is available for connection; blocking.
+* @param error Out-parameter returning any error encountered; set to @ref FACERR_NONE on success.
+*
+* @return A newly instantiated ncpd client corresponding with the device type (EPOC16 or EPOC32); nullptr on failure.
+*/
+template<typename Client, typename Client16, typename Client32>
+Client *connect(const std::string &host, int port, bool waitForServer, Enum<ConnectionError> *error) {
+
+    if (error) {
+        *error = FACERR_NONE;
+    }
+
+    auto socket = std::make_unique<TCPSocket>();
+    if (!socket->connect(host.c_str(), port)) {
+        if (error) {
+            *error = FACERR_CONNECTION_FAILURE;
+        }
+        return nullptr;
+    }
+
+    // At this point the socket is connected to the ncp daemon, which will have (hopefully) seen an INFO exchange, where
+    // the protocol version of the remote Psion was sent, and noted. We have to ask the ncp daemon which protocol it
+    // saw, so we can instantiate the correct RPCS protocol handler for the caller. We announce ourselves to the NCP
+    // daemon, and the relevant RPCS module will also announce itself.
+
+    BufferStore bufferStore;
+
+    bufferStore.addStringT("NCP$INFO");
+    if (!socket->sendBufferStore(bufferStore)) {
+        if (!waitForServer) {
+            if (error) {
+                *error = FACERR_COULD_NOT_SEND;
+            }
+        } else {
+            socket->closeSocket();
+            socket->reconnect();
+            if (error) {
+                *error = FACERR_AGAIN;
+            }
+        }
+        return nullptr;
+    }
+    if (socket->getBufferStore(bufferStore) == 1) {
+        if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 3", 8)) {
+            return new Client16(std::move(socket));
+        }
+        else if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 5", 8)) {
+            return new Client32(std::move(socket));
+        }
+        if ((bufferStore.getLen() > 8) && !strncmp(bufferStore.getString(), "No Psion", 8)) {
+            socket->closeSocket();
+            socket->reconnect();
+            if (error) {
+                *error = FACERR_NOPSION;
+            }
+            return nullptr;
+        }
+        // Invalid protocol version
+        if (error) {
+            *error = FACERR_PROTVERSION;
+        }
+    } else {
+        if (error) {
+            *error = FACERR_NORESPONSE;
+        }
+    }
+
+    // No message returned.
+    return nullptr;
+}
+
+};

--- a/lib/ncpclient.h
+++ b/lib/ncpclient.h
@@ -49,7 +49,7 @@ namespace ncp_client {
 * @return A newly instantiated ncpd client corresponding with the device type (EPOC16 or EPOC32); nullptr on failure.
 */
 template<typename Client, typename Client16, typename Client32>
-Client *connect(const std::string &host, int port, bool waitForServer, Enum<ConnectionError> *error) {
+Client *connect(const std::string &host, int port, bool waitForDevice, Enum<ConnectionError> *error) {
 
     if (error) {
         *error = FACERR_NONE;
@@ -72,7 +72,7 @@ Client *connect(const std::string &host, int port, bool waitForServer, Enum<Conn
 
     bufferStore.addStringT("NCP$INFO");
     if (!socket->sendBufferStore(bufferStore)) {
-        if (!waitForServer) {
+        if (!waitForDevice) {
             if (error) {
                 *error = FACERR_COULD_NOT_SEND;
             }

--- a/lib/ncpclient.h
+++ b/lib/ncpclient.h
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/lib/rfsv.cc
+++ b/lib/rfsv.cc
@@ -22,11 +22,15 @@
  */
 #include "config.h"
 
+#include "rfsv.h"
+
 #include "bufferstore.h"
 #include "drive.h"
 #include "Enum.h"
+#include "ncpclient.h"
 #include "plpdirent.h"
-#include "rfsv.h"
+#include "rfsv16.h"
+#include "rfsv32.h"
 #include "tcpsocket.h"
 
 using namespace std;
@@ -108,6 +112,9 @@ ENUM_DEFINITION_BEGIN(RFSV::errs, RFSV::E_PSI_GEN_NONE)
     stringRep.add(RFSV::E_PSI_INTERNAL,        N_("libplp internal error"));
 ENUM_DEFINITION_END(RFSV::errs)
 
+RFSV *RFSV::connect(const std::string &host, int port, Enum<ConnectionError> *error) {
+    return ncp_client::connect<RFSV, RFSV16, RFSV32>(host, port, false, error);
+}
 
 const char *RFSV::getConnectName(void) {
     return "SYS$RFSV";

--- a/lib/rfsv.h
+++ b/lib/rfsv.h
@@ -19,8 +19,7 @@
  *  along with this program; if not, see <https://www.gnu.org/licenses/>.
  *
  */
-#ifndef _RFSV_H_
-#define _RFSV_H_
+#pragma once
 
 #include <deque>
 #include <memory>
@@ -28,6 +27,7 @@
 #include <vector>
 
 #include "Enum.h"
+#include "connectionerror.h"
 #include "plpdirent.h"
 #include "bufferstore.h"
 
@@ -214,6 +214,8 @@ public:
         PSI_A_STREAM     = 0x0800,
         PSI_A_TEXT       = 0x1000
     };
+
+    static RFSV *connect(const std::string &host, int port, Enum<ConnectionError> *error);
 
     virtual ~RFSV();
     void reset();
@@ -659,5 +661,3 @@ protected:
     Enum<errs> status_;
     int32_t operationId_;
 };
-
-#endif

--- a/lib/rfsv16.h
+++ b/lib/rfsv16.h
@@ -34,13 +34,9 @@ class RFSVFactory;
  * @ref RFSV . For a complete documentation, see @ref RFSV .
  */
 class RFSV16 : public RFSV {
-
-    /**
-     * RFSVFactory may call our constructor.
-     */
-    friend class RFSVFactory;
-
 public:
+    RFSV16(std::unique_ptr<TCPSocket> socket);
+
     Enum<RFSV::errs> fopen(const uint32_t, const char * const, uint32_t &);
     Enum<RFSV::errs> mktemp(uint32_t &, std::string &);
     Enum<RFSV::errs> fcreatefile(const uint32_t, const char * const, uint32_t &);
@@ -134,11 +130,6 @@ private:
         P_FATEXT   = 0x0800, /* is it a text file? */
         P_FAMASK   = 0x0f3f  /* All of the above */
     };
-
-    /**
-    * Private constructor. Shall be called by RFSVFactory only.
-    */
-    RFSV16(std::unique_ptr<TCPSocket> socket);
 
     // Miscellaneous
     Enum<RFSV::errs> fopendir(const char * const, uint32_t &);

--- a/lib/rfsv32.h
+++ b/lib/rfsv32.h
@@ -37,13 +37,9 @@ class RFSVFactory;
  * @ref RFSV . For a complete documentation, see @ref RFSV .
  */
 class RFSV32 : public RFSV {
-
-    /**
-     * RFSVFactory may call our constructor.
-     */
-    friend class RFSVFactory;
-
 public:
+    RFSV32(std::unique_ptr<TCPSocket> socket);
+
     Enum<RFSV::errs> dir(const char * const, PlpDir &);
     Enum<RFSV::errs> dircount(const char * const, uint32_t &);
     Enum<RFSV::errs> copyFromPsion(const char * const, const char * const, void *, cpCallback_t);
@@ -187,12 +183,6 @@ private:
         SET_DRIVE_NAME   = 0x31,
         REPLACE          = 0x32
     };
-
-    /**
-    * Private constructor. Shall be called by
-    * RFSVFactory only.
-    */
-    RFSV32(std::unique_ptr<TCPSocket> socket);
 
     Enum<RFSV::errs> err2psierr(int32_t);
     Enum<RFSV::errs> fopendir(const uint32_t, const char *, uint32_t &);

--- a/lib/rfsvfactory.cc
+++ b/lib/rfsvfactory.cc
@@ -20,18 +20,12 @@
  */
 #include "config.h"
 
+#include "rfsvfactory.h"
+
+#include "ncpclient.h"
 #include "rfsv.h"
 #include "rfsv16.h"
 #include "rfsv32.h"
-#include "rfsvfactory.h"
-#include "bufferstore.h"
-#include "tcpsocket.h"
-#include "Enum.h"
-
-#include <stdlib.h>
-#include <time.h>
-
-using namespace std;
 
 RFSVFactory::RFSVFactory(const std::string &host, int port)
 : host_(host)
@@ -40,64 +34,5 @@ RFSVFactory::RFSVFactory(const std::string &host, int port)
 RFSVFactory::~RFSVFactory() {}
 
 RFSV* RFSVFactory::create(bool reconnect, Enum<ConnectionError> *error) {
-
-    if (error) {
-        *error = FACERR_NONE;
-    }
-
-    auto socket = std::make_unique<TCPSocket>();
-    if (!socket->connect(host_.c_str(), port_)) {
-        if (error) {
-            *error = FACERR_CONNECTION_FAILURE;
-        }
-        return nullptr;
-    }
-
-    // At this point the socket is connected to the ncp daemon, which will have (hopefully) seen an INFO exchange, where
-    // the protocol version of the remote Psion was sent, and noted. We have to ask the ncp daemon which protocol it
-    // saw, so we can instantiate the correct RFSV protocol handler for the caller. We announce ourselves to the NCP
-    // daemon, and the relevant RFSV module will also announce itself.
-
-    BufferStore bufferStore;
-    bufferStore.addStringT("NCP$INFO");
-    if (!socket->sendBufferStore(bufferStore)) {
-        if (!reconnect) {
-            if (error) {
-                *error = FACERR_COULD_NOT_SEND;
-            }
-        } else {
-            socket->closeSocket();
-            socket->reconnect();
-            if (error) {
-                *error = FACERR_AGAIN;
-            }
-        }
-        return NULL;
-    }
-    if (socket->getBufferStore(bufferStore) == 1) {
-        if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 3", 8)) {
-            return new RFSV16(std::move(socket));
-        }
-        else if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 5", 8)) {
-            return new RFSV32(std::move(socket));
-        }
-        if ((bufferStore.getLen() > 8) && !strncmp(bufferStore.getString(), "No Psion", 8)) {
-            socket->closeSocket();
-            socket->reconnect();
-            if (error) {
-                *error = FACERR_NOPSION;
-            }
-            return NULL;
-        }
-        // Invalid protocol version
-        if (error) {
-            *error = FACERR_PROTVERSION;
-        }
-    } else {
-        if (error) {
-            *error = FACERR_NORESPONSE;
-        }
-    }
-
-    return NULL;
+    return ncp_client::connect<RFSV, RFSV16, RFSV32>(host_, port_, reconnect, error);
 }

--- a/lib/rpcs.cc
+++ b/lib/rpcs.cc
@@ -20,15 +20,19 @@
 #include "config.h"
 
 #include "rpcs.h"
-#include "bufferstore.h"
-#include "tcpsocket.h"
-#include "bufferarray.h"
-#include "psiprocess.h"
-#include "Enum.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+
+#include "bufferarray.h"
+#include "bufferstore.h"
+#include "Enum.h"
+#include "ncpclient.h"
+#include "psiprocess.h"
+#include "rpcs16.h"
+#include "rpcs32.h"
+#include "tcpsocket.h"
 
 using namespace std;
 
@@ -85,6 +89,10 @@ ENUM_DEFINITION_BEGIN(RPCS::languages, RPCS::PSI_LANG_TEST)
     stringRep.add(RPCS::PSI_LANG_pl_PL, N_("Polish"));
     stringRep.add(RPCS::PSI_LANG_sl_SI, N_("Slovenian"));
 ENUM_DEFINITION_END(RPCS::languages)
+
+RPCS *RPCS::connect(const std::string &host, int port, Enum<ConnectionError> *error) {
+    return ncp_client::connect<RPCS, RPCS16, RPCS32>(host, port, false, error);
+}
 
 RPCS::~RPCS() {
     socket_->closeSocket();

--- a/lib/rpcs.h
+++ b/lib/rpcs.h
@@ -20,6 +20,7 @@
 #ifndef _RPCS_H_
 #define _RPCS_H_
 
+#include "connectionerror.h"
 #include "psitime.h"
 #include "psiprocess.h"
 #include "rfsv.h"
@@ -158,6 +159,8 @@ public:
         psi_timeval externalPowerUsedTime;
         bool externalPower;
     } machineInfo;
+
+    static RPCS *connect(const std::string &host, int port, Enum<ConnectionError> *error);
 
     /**
     * Virtual destructor.

--- a/lib/rpcs16.h
+++ b/lib/rpcs16.h
@@ -35,13 +35,8 @@ class RPCSFactory;
  * @ref RPCS . For a complete documentation, see @ref RPCS .
  */
 class RPCS16 : public RPCS {
-    friend class RPCSFactory;
-
  public:
+    RPCS16(std::unique_ptr<TCPSocket> socket);
     Enum<RFSV::errs> getCmdLine(const char *, std::string &);
     Enum<RFSV::errs> getOwnerInfo(BufferArray &owner);
-
-
- private:
-    RPCS16(std::unique_ptr<TCPSocket> socket);
 };

--- a/lib/rpcs32.h
+++ b/lib/rpcs32.h
@@ -34,8 +34,6 @@ class RPCSFactory;
  * @ref RPCS . For a complete documentation, see @ref RPCS .
  */
 class RPCS32 : public RPCS {
-    friend class RPCSFactory;
-
  public:
     Enum<RFSV::errs> getCmdLine(const char *, std::string &);
     Enum<RFSV::errs> getMachineInfo(machineInfo &);
@@ -55,9 +53,8 @@ class RPCS32 : public RPCS {
     Enum<RFSV::errs> quitServer(void);
 #endif
 
+    RPCS32(std::unique_ptr<TCPSocket> socket);
+
 protected:
     Enum<RFSV::errs> configOpen(uint16_t &, uint32_t);
-
- private:
-    RPCS32(std::unique_ptr<TCPSocket> socket);
 };

--- a/lib/rpcsfactory.cc
+++ b/lib/rpcsfactory.cc
@@ -20,11 +20,11 @@
  */
 #include "config.h"
 
+#include "ncpclient.h"
+#include "rpcs.h"
 #include "rpcs16.h"
 #include "rpcs32.h"
 #include "rpcsfactory.h"
-#include "bufferstore.h"
-#include "tcpsocket.h"
 #include "Enum.h"
 
 #include <stdlib.h>
@@ -37,66 +37,5 @@ RPCSFactory::RPCSFactory(const std::string &host, int port)
 RPCSFactory::~RPCSFactory() {}
 
 RPCS *RPCSFactory::create(bool reconnect, Enum<ConnectionError> *error) {
-
-    if (error) {
-        *error = FACERR_NONE;
-    }
-
-    auto socket = std::make_unique<TCPSocket>();
-    if (!socket->connect(host_.c_str(), port_)) {
-        if (error) {
-            *error = FACERR_CONNECTION_FAILURE;
-        }
-        return nullptr;
-    }
-
-    // At this point the socket is connected to the ncp daemon, which will have (hopefully) seen an INFO exchange, where
-    // the protocol version of the remote Psion was sent, and noted. We have to ask the ncp daemon which protocol it
-    // saw, so we can instantiate the correct RPCS protocol handler for the caller. We announce ourselves to the NCP
-    // daemon, and the relevant RPCS module will also announce itself.
-
-    BufferStore bufferStore;
-
-    bufferStore.addStringT("NCP$INFO");
-    if (!socket->sendBufferStore(bufferStore)) {
-        if (!reconnect) {
-            if (error) {
-                *error = FACERR_COULD_NOT_SEND;
-            }
-        } else {
-            socket->closeSocket();
-            socket->reconnect();
-            if (error) {
-                *error = FACERR_AGAIN;
-            }
-        }
-        return nullptr;
-    }
-    if (socket->getBufferStore(bufferStore) == 1) {
-        if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 3", 8)) {
-            return new RPCS16(std::move(socket));
-        }
-        else if (bufferStore.getLen() > 8 && !strncmp(bufferStore.getString(), "Series 5", 8)) {
-            return new RPCS32(std::move(socket));
-        }
-        if ((bufferStore.getLen() > 8) && !strncmp(bufferStore.getString(), "No Psion", 8)) {
-            socket->closeSocket();
-            socket->reconnect();
-            if (error) {
-                *error = FACERR_NOPSION;
-            }
-            return nullptr;
-        }
-        // Invalid protocol version
-        if (error) {
-            *error = FACERR_PROTVERSION;
-        }
-    } else {
-        if (error) {
-            *error = FACERR_NORESPONSE;
-        }
-    }
-
-    // No message returned.
-    return nullptr;
+    return ncp_client::connect<RPCS, RPCS16, RPCS32>(host_, port_, reconnect, error);
 }

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -94,8 +94,7 @@ void ftpHeader() {
 int main(int argc, char **argv) {
     FTP ftp;
     string host = "127.0.0.1";
-    int status = 0;
-    int sockNum = cli_utils::lookup_default_port();
+    int port = cli_utils::lookup_default_port();
 
     setlocale (LC_ALL, "");
     textdomain(PACKAGE);
@@ -115,7 +114,7 @@ int main(int argc, char **argv) {
                 help();
                 return 0;
             case 'p':
-                if (!cli_utils::parse_port(optarg, &host, &sockNum)) {
+                if (!cli_utils::parse_port(optarg, &host, &port)) {
                     cout << _("Invalid port definition.") << endl;
                     return 1;
                 }
@@ -127,17 +126,17 @@ int main(int argc, char **argv) {
     }
 
     Enum<ConnectionError> error;
-    auto rfsv = std::unique_ptr<RFSV>(RFSV::connect(host, sockNum, &error));
+    auto rfsv = std::unique_ptr<RFSV>(RFSV::connect(host, port, &error));
     if (!rfsv) {
         cerr << "plpftp: " << error << endl;
         return EXIT_FAILURE;
     }
-    auto rpcs = std::unique_ptr<RPCS>(RPCS::connect(host, sockNum, &error));
+    auto rpcs = std::unique_ptr<RPCS>(RPCS::connect(host, port, &error));
     if (!rpcs) {
         cerr << "plpftp: " << error << endl;
         return EXIT_FAILURE;
     }
-    auto clipboard = std::unique_ptr<rclip>(rclip::connect(host, sockNum, &error));
+    auto clipboard = std::unique_ptr<rclip>(rclip::connect(host, port, &error));
     if (!clipboard) {
         cerr << "plpftp: " << error << endl;
         return EXIT_FAILURE;

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -126,16 +126,13 @@ int main(int argc, char **argv) {
         ftpHeader();
     }
 
-    auto rfsvFactory = std::make_unique<RFSVFactory>(host, sockNum);
-    auto rpcsFactory = std::make_unique<RPCSFactory>(host, sockNum);
-
     Enum<ConnectionError> error;
-    auto rfsv = std::unique_ptr<RFSV>(rfsvFactory->create(false, &error));
+    auto rfsv = std::unique_ptr<RFSV>(RFSV::connect(host, sockNum, &error));
     if (!rfsv) {
         cerr << "plpftp: " << error << endl;
         return EXIT_FAILURE;
     }
-    auto rpcs = std::unique_ptr<RPCS>(rpcsFactory->create(false, &error));
+    auto rpcs = std::unique_ptr<RPCS>(RPCS::connect(host, sockNum, &error));
     if (!rpcs) {
         cerr << "plpftp: " << error << endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
This change introduce a new `ncp_client` namespace with a single templated function, `connect`, which will perform the ncpd connection bootstrap to determine the type of device connected (EPOC16 or EPOC32) and instantiate the correct client (`RFSV16`, `RFSV32`, `RPCS16`, `RPCS32`, etc). This will stop these implementations diverging in the future and gives us nicely reusable code for a future separation of the clipboard client.