### PR TITLE
fix: Simplify the plpftp preamble

### DIFF
--- a/plpftp/ftp.cc
+++ b/plpftp/ftp.cc
@@ -549,20 +549,12 @@ int FTP::session(RFSV &rfsv, RPCS &rpcs, rclip &clipboard, vector<char *> argv) 
 
     {
         Enum<RPCS::machs> machType;
-        BufferArray b;
-        if ((res = rpcs.getOwnerInfo(b)) == RFSV::E_PSI_GEN_NONE) {
-            rpcs.getMachineType(machType);
-            if (!once) {
-                int speed = rfsv.getSpeed();
-                cout << _("Connected to a ") << machType << _(" at ")
-                     << speed << _(" baud, OwnerInfo:") << endl;
-                while (!b.empty()) {
-                    cout << "  " << b.pop().getString() << endl;
-                }
-                cout << endl;
-            }
-        } else {
-            cerr << _("OwnerInfo returned error ") << res << endl;
+        rpcs.getMachineType(machType);
+        if (!once) {
+            int speed = rfsv.getSpeed();
+            cout << _("Connected to a ") << machType << _(" at ")
+                 << speed << _(" baud.") << endl;
+            cout << endl;
         }
     }
 

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -80,7 +80,8 @@ static struct option opts[] = {
 
 void ftpHeader() {
     cout << _("PLPFTP Version ") << VERSION << endl;
-    cout << _("FTP like interface started. Type \"?\" for help.") << endl << endl;
+    cout << _("FTP like interface started. Type \"?\" for help.") << endl;
+    cout << endl;
 }
 
 int main(int argc, char **argv) {

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -79,16 +79,8 @@ static struct option opts[] = {
 };
 
 void ftpHeader() {
-    cout << _("PLPFTP Version ") << VERSION;
-    cout << _(" Copyright (C) 1999 Philip Proudman") << endl;
-    cout << _(" Additions Copyright (C) 1999-2002 Fritz Elfert <felfert@to.com>") << endl;
-    cout << _("                   & (C) 1999 Matt Gumbley <matt@gumbley.demon.co.uk>") << endl;
-    cout << _("                   & (C) 2006-2025 Reuben Thomas <rrt@sc3d.org>") << endl;
-    cout << _("PLPFTP comes with ABSOLUTELY NO WARRANTY.") << endl;
-    cout << _("This is free software, and you are welcome to redistribute it") << endl;
-    cout << _("under GPL conditions; see the COPYING file in the distribution.") << endl;
-    cout << endl;
-    cout << _("FTP like interface started. Type \"?\" for help.") << endl;
+    cout << _("PLPFTP Version ") << VERSION << endl;
+    cout << _("FTP like interface started. Type \"?\" for help.") << endl << endl;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This change removes the unnecessary copyright and license notice from the plpftp preamble and no longer performs the initial owner info fetch.