### PR TITLE
fix: Remove custom `Enum` assignment operator

### DIFF
--- a/lib/Enum.h
+++ b/lib/Enum.h
@@ -194,12 +194,6 @@ public:
         return *this;
     }
 
-    inline Enum& operator = (const Enum& rhs) {
-        if (&rhs != this)
-            value = rhs.value;
-        return *this;
-    }
-
     /**
     * returns the enumeration value hold with this
     * enum.


### PR DESCRIPTION
We don't need to override the assignment operator; we should use the compiler default. Addresses some compiler warnings.