### PR TITLE
refactor: Move `DeviceEndpoint` into a separate file

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -36,6 +36,7 @@ libplp_la_SOURCES = \
 	datalink.cc \
 	device.cc \
 	deviceconfiguration.cc \
+	deviceendpoint.cc \
 	drive.cc \
 	Enum.cc \
 	fakepsion.cc \
@@ -84,6 +85,7 @@ noinst_HEADERS = \
 	datalink.h \
 	device.h \
 	deviceconfiguration.h \
+	deviceendpoint.h \
 	drive.h \
 	Enum.h \
 	fakepsion.h \

--- a/lib/device.cc
+++ b/lib/device.cc
@@ -28,64 +28,9 @@
 #include <cstdint>
 #include <memory>
 
-#include "connectionerror.h"
 #include "deviceconfiguration.h"
 #include "pathutils.h"
-#include "rclip.h"
 #include "rfsv.h"
-#include "rpcs.h"
-#include "uuid.h"
-
-device::DeviceEndpoint::DeviceEndpoint(const std::string &id,
-                                       std::unique_ptr<RFSV> rfsv,
-                                       std::unique_ptr<RPCS> rpcs,
-                                       std::unique_ptr<rclip> clip)
-: id_(id)
-, rfsv_(std::move(rfsv))
-, rpcs_(std::move(rpcs))
-, clip_(std::move(clip)) {}
-
-std::unique_ptr<device::DeviceEndpoint> device::connect(const std::string host,
-                                                        int port,
-                                                        Enum<ConnectionError> *error) {
-    Enum<ConnectionError> internalError = ConnectionError::FACERR_NONE;
-    auto rfsv = std::unique_ptr<RFSV>(RFSV::connect(host, port, &internalError));
-    if (!rfsv) {
-        if (error) {
-            *error = internalError;
-        }
-        return nullptr;
-    }
-
-    // Get the device configuration.
-    Enum<RFSV::errs> result;
-    auto deviceConfiguration = device::read_configuration(*rfsv, result);
-    if (!deviceConfiguration) {
-        // Create and write a new device configuration if it doesn't exist.
-        // We ignore errors here as we want failures to write the device configuration to be non-fatal. For example., if
-        // the device is out of memory, it's acceptable for it to appear as a new device on each connection.
-        deviceConfiguration = std::make_unique<DeviceConfiguration>(uuid::uuid4(), _("My Psion"));
-        device::write_configuration(*rfsv, *deviceConfiguration);
-    }
-
-    auto rpcs = std::unique_ptr<RPCS>(RPCS::connect(host, port, &internalError));
-    if (!rpcs) {
-        if (error) {
-            *error = internalError;
-        }
-        return nullptr;
-    }
-
-    auto clip = std::unique_ptr<rclip>(rclip::connect(host, port, &internalError));
-    if (!clip) {
-        if (error) {
-            *error = internalError;
-        }
-        return nullptr;
-    }
-
-    return std::make_unique<device::DeviceEndpoint>(deviceConfiguration->id(), std::move(rfsv), std::move(rpcs), std::move(clip));
-}
 
 Enum<RFSV::errs> device::write_configuration(RFSV &rfsv, const DeviceConfiguration &deviceConfiguration) {
     std::string configurationPath = rfsv.deviceConfigurationPath();

--- a/lib/deviceendpoint.cc
+++ b/lib/deviceendpoint.cc
@@ -1,0 +1,83 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+
+#include <memory>
+#include <string>
+
+#include "deviceendpoint.h"
+
+#include "device.h"
+#include "deviceconfiguration.h"
+#include "rclip.h"
+#include "rfsv.h"
+#include "rpcs.h"
+#include "uuid.h"
+
+std::unique_ptr<DeviceEndpoint> DeviceEndpoint::connect(const std::string host,
+                                                        int port,
+                                                        Enum<ConnectionError> *error) {
+    Enum<ConnectionError> internalError = ConnectionError::FACERR_NONE;
+    auto rfsv = std::unique_ptr<RFSV>(RFSV::connect(host, port, &internalError));
+    if (!rfsv) {
+        if (error) {
+            *error = internalError;
+        }
+        return nullptr;
+    }
+
+    // Get the device configuration.
+    Enum<RFSV::errs> result;
+    auto deviceConfiguration = device::read_configuration(*rfsv, result);
+    if (!deviceConfiguration) {
+        // Create and write a new device configuration if it doesn't exist.
+        // We ignore errors here as we want failures to write the device configuration to be non-fatal. For example., if
+        // the device is out of memory, it's acceptable for it to appear as a new device on each connection.
+        deviceConfiguration = std::make_unique<DeviceConfiguration>(uuid::uuid4(), _("My Psion"));
+        device::write_configuration(*rfsv, *deviceConfiguration);
+    }
+
+    auto rpcs = std::unique_ptr<RPCS>(RPCS::connect(host, port, &internalError));
+    if (!rpcs) {
+        if (error) {
+            *error = internalError;
+        }
+        return nullptr;
+    }
+
+    auto clip = std::unique_ptr<rclip>(rclip::connect(host, port, &internalError));
+    if (!clip) {
+        if (error) {
+            *error = internalError;
+        }
+        return nullptr;
+    }
+
+    return std::make_unique<DeviceEndpoint>(deviceConfiguration->id(), std::move(rfsv), std::move(rpcs), std::move(clip));
+}
+
+DeviceEndpoint::DeviceEndpoint(const std::string &id,
+                               std::unique_ptr<RFSV> rfsv,
+                               std::unique_ptr<RPCS> rpcs,
+                               std::unique_ptr<rclip> clip)
+: id_(id)
+, rfsv_(std::move(rfsv))
+, rpcs_(std::move(rpcs))
+, clip_(std::move(clip)) {}

--- a/lib/deviceendpoint.h
+++ b/lib/deviceendpoint.h
@@ -1,10 +1,7 @@
 /*
  * This file is part of plptools.
  *
- *  Copyright (C) 1999 Philip Proudman <philip.proudman@btinternet.com>
- *  Copyright (C) 1999-2002 Fritz Elfert <felfert@to.com>
- *  Copyright (C) 2006-2025 Reuben Thomas <rrt@sc3d.org>
- *  Copyright (C) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -22,22 +19,29 @@
  */
 #pragma once
 
-#include "config.h"
-
 #include <memory>
+#include <string>
 
-#include "rfsv.h"
+#include "connectionerror.h"
+#include "Enum.h"
 
-class DeviceConfiguration;
-class DeviceEndpoint;
 class rclip;
 class RFSV;
 class RPCS;
 
-namespace device {
+class DeviceEndpoint {
+public:
 
-extern Enum<RFSV::errs> write_configuration(RFSV &rfsv, const DeviceConfiguration &deviceConfiguration);
+    static std::unique_ptr<DeviceEndpoint> connect(const std::string host, int port, Enum<ConnectionError> *error);
 
-extern std::unique_ptr<DeviceConfiguration> read_configuration(RFSV &rfsv, Enum<RFSV::errs> &error);
+    DeviceEndpoint(const std::string &id,
+                   std::unique_ptr<RFSV> rfsv,
+                   std::unique_ptr<RPCS> rpcs,
+                   std::unique_ptr<rclip> clip);
+
+    const std::string id_;
+    const std::unique_ptr<RFSV> rfsv_;
+    const std::unique_ptr<RPCS> rpcs_;
+    const std::unique_ptr<rclip> clip_;
 
 };

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -27,6 +27,7 @@
 #include <bufferstore.h>
 #include <cliutils.h>
 #include <device.h>
+#include <deviceendpoint.h>
 #include <deviceconfiguration.h>
 #include <plpintl.h>
 #include <rclip.h>
@@ -121,7 +122,7 @@ int main(int argc, char **argv) {
     }
 
     Enum<ConnectionError> error;
-    auto deviceEndpoint = device::connect(host, port, &error);
+    auto deviceEndpoint = DeviceEndpoint::connect(host, port, &error);
     if (!deviceEndpoint) {
         std::cerr << "plpftp: " << error << std::endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
This also moves the bootstrapping connection code into `DeviceEndpoint` as a static factory constructor.