### PR TITLE
fix: Only create the device configuration when setting a device name

### DIFF
--- a/lib/deviceendpoint.cc
+++ b/lib/deviceendpoint.cc
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <string>
+#include <system_error>
 
 #include "deviceendpoint.h"
 
@@ -46,13 +47,8 @@ std::unique_ptr<DeviceEndpoint> DeviceEndpoint::connect(const std::string host,
     // Get the device configuration.
     Enum<RFSV::errs> result;
     auto deviceConfiguration = device::read_configuration(*rfsv, result);
-    if (!deviceConfiguration) {
-        // Create and write a new device configuration if it doesn't exist.
-        // We ignore errors here as we want failures to write the device configuration to be non-fatal. For example., if
-        // the device is out of memory, it's acceptable for it to appear as a new device on each connection.
-        deviceConfiguration = std::make_unique<DeviceConfiguration>(uuid::uuid4(), _("My Psion"));
-        device::write_configuration(*rfsv, *deviceConfiguration);
-    }
+    std::string id = deviceConfiguration ? deviceConfiguration->id() : uuid::uuid4();
+    bool persistentId = static_cast<bool>(deviceConfiguration);
 
     auto rpcs = std::unique_ptr<RPCS>(RPCS::connect(host, port, &internalError));
     if (!rpcs) {
@@ -70,14 +66,39 @@ std::unique_ptr<DeviceEndpoint> DeviceEndpoint::connect(const std::string host,
         return nullptr;
     }
 
-    return std::make_unique<DeviceEndpoint>(deviceConfiguration->id(), std::move(rfsv), std::move(rpcs), std::move(clip));
+    return std::make_unique<DeviceEndpoint>(id, persistentId, std::move(rfsv), std::move(rpcs), std::move(clip));
 }
 
 DeviceEndpoint::DeviceEndpoint(const std::string &id,
+                               bool persistentId,
                                std::unique_ptr<RFSV> rfsv,
                                std::unique_ptr<RPCS> rpcs,
                                std::unique_ptr<rclip> clip)
-: id_(id)
-, rfsv_(std::move(rfsv))
+: rfsv_(std::move(rfsv))
 , rpcs_(std::move(rpcs))
-, clip_(std::move(clip)) {}
+, clip_(std::move(clip))
+, id_(id)
+, hasPersisentId_(persistentId) {}
+
+std::string DeviceEndpoint::id() {
+    return id_;
+}
+
+Enum<RFSV::errs> DeviceEndpoint::getName(std::string &name) {
+    Enum<RFSV::errs> error = RFSV::E_PSI_GEN_NONE;
+    auto deviceConfiguration = device::read_configuration(*rfsv_, error);
+    if (error != RFSV::E_PSI_GEN_NONE) {
+        return error;
+    }
+    name = deviceConfiguration->name();
+    return RFSV::E_PSI_GEN_NONE;
+}
+
+Enum<RFSV::errs> DeviceEndpoint::setName(const std::string &name) {
+    auto deviceConfiguration = std::make_unique<DeviceConfiguration>(id_, name);
+    auto result = device::write_configuration(*rfsv_, *deviceConfiguration);
+    if (result == RFSV::E_PSI_GEN_NONE) {
+        hasPersisentId_ = true;
+    }
+    return result;
+}

--- a/lib/deviceendpoint.cc
+++ b/lib/deviceendpoint.cc
@@ -66,7 +66,8 @@ std::unique_ptr<DeviceEndpoint> DeviceEndpoint::connect(const std::string host,
         return nullptr;
     }
 
-    return std::make_unique<DeviceEndpoint>(id, persistentId, std::move(rfsv), std::move(rpcs), std::move(clip));
+    return std::unique_ptr<DeviceEndpoint>(
+        new DeviceEndpoint(id, persistentId, std::move(rfsv), std::move(rpcs), std::move(clip)));
 }
 
 DeviceEndpoint::DeviceEndpoint(const std::string &id,
@@ -78,13 +79,17 @@ DeviceEndpoint::DeviceEndpoint(const std::string &id,
 , rpcs_(std::move(rpcs))
 , clip_(std::move(clip))
 , id_(id)
-, hasPersisentId_(persistentId) {}
+, hasPersistentId_(persistentId) {}
 
-std::string DeviceEndpoint::id() {
+std::string DeviceEndpoint::id() const {
     return id_;
 }
 
-Enum<RFSV::errs> DeviceEndpoint::getName(std::string &name) {
+bool DeviceEndpoint::hasPersistentId() const {
+    return hasPersistentId_;
+}
+
+Enum<RFSV::errs> DeviceEndpoint::getName(std::string &name) const {
     Enum<RFSV::errs> error = RFSV::E_PSI_GEN_NONE;
     auto deviceConfiguration = device::read_configuration(*rfsv_, error);
     if (error != RFSV::E_PSI_GEN_NONE) {
@@ -98,7 +103,7 @@ Enum<RFSV::errs> DeviceEndpoint::setName(const std::string &name) {
     auto deviceConfiguration = std::make_unique<DeviceConfiguration>(id_, name);
     auto result = device::write_configuration(*rfsv_, *deviceConfiguration);
     if (result == RFSV::E_PSI_GEN_NONE) {
-        hasPersisentId_ = true;
+        hasPersistentId_ = true;
     }
     return result;
 }

--- a/lib/deviceendpoint.cc
+++ b/lib/deviceendpoint.cc
@@ -21,7 +21,6 @@
 
 #include <memory>
 #include <string>
-#include <system_error>
 
 #include "deviceendpoint.h"
 
@@ -48,7 +47,7 @@ std::unique_ptr<DeviceEndpoint> DeviceEndpoint::connect(const std::string host,
     Enum<RFSV::errs> result;
     auto deviceConfiguration = device::read_configuration(*rfsv, result);
     std::string id = deviceConfiguration ? deviceConfiguration->id() : uuid::uuid4();
-    bool persistentId = static_cast<bool>(deviceConfiguration);
+    bool hasPersistentConfiguration = static_cast<bool>(deviceConfiguration);
 
     auto rpcs = std::unique_ptr<RPCS>(RPCS::connect(host, port, &internalError));
     if (!rpcs) {
@@ -67,11 +66,11 @@ std::unique_ptr<DeviceEndpoint> DeviceEndpoint::connect(const std::string host,
     }
 
     return std::unique_ptr<DeviceEndpoint>(
-        new DeviceEndpoint(id, persistentId, std::move(rfsv), std::move(rpcs), std::move(clip)));
+        new DeviceEndpoint(id, hasPersistentConfiguration, std::move(rfsv), std::move(rpcs), std::move(clip)));
 }
 
 DeviceEndpoint::DeviceEndpoint(const std::string &id,
-                               bool persistentId,
+                               bool hasPersistentConfiguration,
                                std::unique_ptr<RFSV> rfsv,
                                std::unique_ptr<RPCS> rpcs,
                                std::unique_ptr<rclip> clip)
@@ -79,22 +78,38 @@ DeviceEndpoint::DeviceEndpoint(const std::string &id,
 , rpcs_(std::move(rpcs))
 , clip_(std::move(clip))
 , id_(id)
-, hasPersistentId_(persistentId) {}
+, hasPersistentConfiguration_(hasPersistentConfiguration) {}
 
 std::string DeviceEndpoint::id() const {
     return id_;
 }
 
 bool DeviceEndpoint::hasPersistentId() const {
-    return hasPersistentId_;
+    return hasPersistentConfiguration_;
 }
 
 Enum<RFSV::errs> DeviceEndpoint::getName(std::string &name) const {
+
+    // Don't bother to fetch the configuration if we know it does't exist.
+    if (!hasPersistentConfiguration_) {
+        return RFSV::E_PSI_FILE_RECORD;
+    }
+
+    // Read the configuration.
     Enum<RFSV::errs> error = RFSV::E_PSI_GEN_NONE;
     auto deviceConfiguration = device::read_configuration(*rfsv_, error);
+
+    // Check for E_PSI_FILE_NXIST and return it as E_PSI_FILE_RECORD which seems more logical.
+    if (error == RFSV::E_PSI_FILE_NXIST) {
+        return RFSV::E_PSI_FILE_RECORD;
+    }
+
+    // Return any errors.
     if (error != RFSV::E_PSI_GEN_NONE) {
         return error;
     }
+
+    // Update the name and indicate success.
     name = deviceConfiguration->name();
     return RFSV::E_PSI_GEN_NONE;
 }
@@ -103,7 +118,7 @@ Enum<RFSV::errs> DeviceEndpoint::setName(const std::string &name) {
     auto deviceConfiguration = std::make_unique<DeviceConfiguration>(id_, name);
     auto result = device::write_configuration(*rfsv_, *deviceConfiguration);
     if (result == RFSV::E_PSI_GEN_NONE) {
-        hasPersistentId_ = true;
+        hasPersistentConfiguration_ = true;
     }
     return result;
 }

--- a/lib/deviceendpoint.h
+++ b/lib/deviceendpoint.h
@@ -24,6 +24,7 @@
 
 #include "connectionerror.h"
 #include "Enum.h"
+#include "device.h"
 
 class rclip;
 class RFSV;
@@ -35,13 +36,21 @@ public:
     static std::unique_ptr<DeviceEndpoint> connect(const std::string host, int port, Enum<ConnectionError> *error);
 
     DeviceEndpoint(const std::string &id,
+                   bool persistentId,
                    std::unique_ptr<RFSV> rfsv,
                    std::unique_ptr<RPCS> rpcs,
                    std::unique_ptr<rclip> clip);
 
-    const std::string id_;
+    std::string id();
+
+    Enum<RFSV::errs> getName(std::string &name);
+    Enum<RFSV::errs> setName(const std::string &name);
+
     const std::unique_ptr<RFSV> rfsv_;
     const std::unique_ptr<RPCS> rpcs_;
     const std::unique_ptr<rclip> clip_;
 
+private:
+    const std::string id_;
+    bool hasPersisentId_;
 };

--- a/lib/deviceendpoint.h
+++ b/lib/deviceendpoint.h
@@ -35,15 +35,35 @@ public:
 
     static std::unique_ptr<DeviceEndpoint> connect(const std::string host, int port, Enum<ConnectionError> *error);
 
-    DeviceEndpoint(const std::string &id,
-                   bool persistentId,
-                   std::unique_ptr<RFSV> rfsv,
-                   std::unique_ptr<RPCS> rpcs,
-                   std::unique_ptr<rclip> clip);
+    /**
+    * Device identifier.
+    *
+    * The device identifier is guaranteed to be session-stable but isn't guaranteed to be persisted to disk. Use
+    * @ref hasPersistentId to check if the identifier is persistent. The identifier can be persisted by setting the
+    * device name using @ref setName.
+    *
+    * @return String containing the device identifier.
+    */
+    std::string id() const;
 
-    std::string id();
+    bool hasPersistentId() const;
 
-    Enum<RFSV::errs> getName(std::string &name);
+    /**
+    * Get the device name.
+    *
+    * @param name Out-param for the device name.
+    *
+    * @result @ref RFSV::E_PSI_GEN_NONE on success; error otherwise.
+    */
+    Enum<RFSV::errs> getName(std::string &name) const;
+
+    /**
+    * Set the device name.
+    *
+    * @param name New device name.
+    *
+    * @result @ref RFSV::E_PSI_GEN_NONE on success; error otherwise.
+    */
     Enum<RFSV::errs> setName(const std::string &name);
 
     const std::unique_ptr<RFSV> rfsv_;
@@ -51,6 +71,13 @@ public:
     const std::unique_ptr<rclip> clip_;
 
 private:
+
+    DeviceEndpoint(const std::string &id,
+                   bool persistentId,
+                   std::unique_ptr<RFSV> rfsv,
+                   std::unique_ptr<RPCS> rpcs,
+                   std::unique_ptr<rclip> clip);
+
     const std::string id_;
-    bool hasPersisentId_;
+    bool hasPersistentId_;
 };

--- a/lib/deviceendpoint.h
+++ b/lib/deviceendpoint.h
@@ -19,6 +19,8 @@
  */
 #pragma once
 
+#include "config.h"
+
 #include <memory>
 #include <string>
 
@@ -53,6 +55,8 @@ public:
     *
     * @param name Out-param for the device name.
     *
+    * A return value of @ref RFSV::E_PSI_FILE_RECORD indicates that the device name has not been set.
+    *
     * @result @ref RFSV::E_PSI_GEN_NONE on success; error otherwise.
     */
     Enum<RFSV::errs> getName(std::string &name) const;
@@ -73,11 +77,11 @@ public:
 private:
 
     DeviceEndpoint(const std::string &id,
-                   bool persistentId,
+                   bool hasPersistentConfiguration,
                    std::unique_ptr<RFSV> rfsv,
                    std::unique_ptr<RPCS> rpcs,
                    std::unique_ptr<rclip> clip);
 
     const std::string id_;
-    bool hasPersistentId_;
+    bool hasPersistentConfiguration_;
 };

--- a/plpftp/ftp.cc
+++ b/plpftp/ftp.cc
@@ -53,8 +53,8 @@
 #include <signal.h>
 #include <netdb.h>
 #include <fnmatch.h>
-#include <device.h>
 #include <deviceconfiguration.h>
+#include <deviceendpoint.h>
 
 #include "ignore-value.h"
 #include "string-buffer.h"
@@ -543,7 +543,7 @@ static char *epoc_dir_from(const char *path) {
     return f1;
 }
 
-int FTP::session(RFSV &rfsv, RPCS &rpcs, rclip &clipboard, vector<char *> argv) {
+int FTP::session(DeviceEndpoint &deviceEndpoint, RFSV &rfsv, RPCS &rpcs, rclip &clipboard, vector<char *> argv) {
     Enum<RFSV::errs> res;
     bool prompt = true;
     bool hash = false;
@@ -556,21 +556,18 @@ int FTP::session(RFSV &rfsv, RPCS &rpcs, rclip &clipboard, vector<char *> argv) 
     }
 
     {
-        Enum<RFSV::errs> error;
-        auto deviceConfiguration = device::read_configuration(rfsv, error);
-        if (!deviceConfiguration) {
-            cerr << _("Error: ") << error << endl;
-        }
+        std::string name;
+        auto nameError = deviceEndpoint.getName(name);
 
         Enum<RPCS::machs> machType;
         rpcs.getMachineType(machType);
         if (!once) {
             int speed = rfsv.getSpeed();
-            if (deviceConfiguration) {
-                cout << _("Connected to '") << deviceConfiguration->name() << _("', a ") << machType << _(", at ")
-                     << speed << _(" baud.") << endl;
-            } else {
+            if (nameError != RFSV::E_PSI_GEN_NONE) {
                 cout << _("Connected to a ") << machType << _(", at ") << speed << _(" baud.") << endl;
+            } else {
+                cout << _("Connected to '") << name << _("', a ") << machType << _(", at ")
+                     << speed << _(" baud.") << endl;
             }
             cout << endl;
         }
@@ -739,35 +736,22 @@ int FTP::session(RFSV &rfsv, RPCS &rpcs, rclip &clipboard, vector<char *> argv) 
             continue;
         }
         if (!strcmp(argv[0], "deviceid") && (argc == 1)) {
-            Enum<RFSV::errs> error = RFSV::E_PSI_GEN_NONE;
-            auto deviceConfiguration = device::read_configuration(rfsv, error);
-            if (!deviceConfiguration) {
-                cerr << _("Error: ") << error << endl;
-                continue;
-            }
-            cout << deviceConfiguration->id() << endl;
+            cout << deviceEndpoint.id() << endl;
             continue;
         }
         if (!strcmp(argv[0], "devicename") && (argc == 1)) {
-            Enum<RFSV::errs> error = RFSV::E_PSI_GEN_NONE;
-            auto deviceConfiguration = device::read_configuration(rfsv, error);
-            if (!deviceConfiguration) {
+            std::string name;
+            auto error = deviceEndpoint.getName(name);
+            if (error != RFSV::E_PSI_GEN_NONE) {
                 cerr << _("Error: ") << error << endl;
                 continue;
             }
-            cout << deviceConfiguration->name() << endl;
+            cout << name << endl;
             continue;
         }
         if (!strcmp(argv[0], "setdevicename") && (argc == 2)) {
             std::string name = argv[1];
-            Enum<RFSV::errs> error = RFSV::E_PSI_GEN_NONE;
-            auto deviceConfiguration = device::read_configuration(rfsv, error);
-            if (!deviceConfiguration) {
-                cerr << _("Error: ") << error << endl;
-                continue;
-            }
-            deviceConfiguration->setName(argv[1]);
-            error = device::write_configuration(rfsv, *deviceConfiguration);
+            auto error = deviceEndpoint.setName(name);
             if (error != RFSV::E_PSI_GEN_NONE) {
                 cerr << _("Error: ") << error << endl;
                 continue;

--- a/plpftp/ftp.cc
+++ b/plpftp/ftp.cc
@@ -29,7 +29,6 @@
 #include <cstdlib>
 #include <drive.h>
 #include <Enum.h>
-#include <memory>
 #include <pathutils.h>
 #include <plpintl.h>
 #include <rclip.h>
@@ -146,7 +145,7 @@ void FTP::usage() {
     cout << endl << _("Device commands:") << endl << endl;
     cout << "  deviceid - get the device id used for backup and sync" << endl;
     cout << "  devicename - get the device name used for backup and sync" << endl;
-    cout << "  setdevicename <name> - set the device name used for backup and sync" << endl;
+    cout << "  setdevicename <name> - set the device name and persist the id used for backup and sync" << endl;
     cout << endl;
 }
 
@@ -737,16 +736,21 @@ int FTP::session(DeviceEndpoint &deviceEndpoint, RFSV &rfsv, RPCS &rpcs, rclip &
         }
         if (!strcmp(argv[0], "deviceid") && (argc == 1)) {
             cout << deviceEndpoint.id() << endl;
+            if (!deviceEndpoint.hasPersistentId()) {
+                cout << _("Warning: ") << _("not persistent; use setdevicename to set a name and persist the device id") << endl;
+            }
             continue;
         }
         if (!strcmp(argv[0], "devicename") && (argc == 1)) {
             std::string name;
             auto error = deviceEndpoint.getName(name);
-            if (error != RFSV::E_PSI_GEN_NONE) {
+            if (error == RFSV::E_PSI_GEN_NONE) {
+                cout << name << endl;
+            } else if (error == RFSV::E_PSI_FILE_RECORD) {
+                cout << _("Error: ") << "not set; use setdevicename to set a name and persist the device id" << endl;
+            } else {
                 cerr << _("Error: ") << error << endl;
-                continue;
             }
-            cout << name << endl;
             continue;
         }
         if (!strcmp(argv[0], "setdevicename") && (argc == 2)) {

--- a/plpftp/ftp.h
+++ b/plpftp/ftp.h
@@ -37,7 +37,7 @@ class FTP {
 public:
     FTP();
     ~FTP();
-    int session(RFSV &rfsv, RPCS &rpcs, rclip &clipboard, std::vector<char *> argv);
+    int session(DeviceEndpoint &deviceEndpoint, RFSV &rfsv, RPCS &rpcs, rclip &clipboard, std::vector<char *> argv);
 
 private:
     std::vector<char *> getCommand();

--- a/plpftp/ftp.h
+++ b/plpftp/ftp.h
@@ -23,15 +23,15 @@
 
 #include "config.h"
 
-#include <memory>
 #include <vector>
 
 #include "rfsv.h"
-#include "Enum.h"
 
-class RPCS;
-class BufferStore;
 class BufferArray;
+class BufferStore;
+class DeviceEndpoint;
+class RPCS;
+class rclip;
 
 class FTP {
 public:

--- a/plpftp/main.cc
+++ b/plpftp/main.cc
@@ -128,5 +128,5 @@ int main(int argc, char **argv) {
         return EXIT_FAILURE;
     }
     vector<char *> args(argv + optind, argv + argc);
-    return ftp.session(*deviceEndpoint->rfsv_, *deviceEndpoint->rpcs_, *deviceEndpoint->clip_, args);
+    return ftp.session(*deviceEndpoint, *deviceEndpoint->rfsv_, *deviceEndpoint->rpcs_, *deviceEndpoint->clip_, args);
 }


### PR DESCRIPTION
Following discussions, we’ve decided that connecting using plpftp should be side-effect free. This change implements that by continuing to generate a session-stable identifier for `DeviceEndpoint` but doesn’t serialize it to the device until the user sets the name using `setdevicename`.

Internal to `DeviceEndpoint` we introduce a new member variable `hasPersistentId_` to allow us to track whether the id has been written to (or read from) the Psion. This should allow us to gate future features that require stable ids (e.g., backup) and implement workflows that prompt the user to persist the id.