### PR TITLE
fix: Cache the device name

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -100,6 +100,7 @@ noinst_HEADERS = \
 	ncpclient.h \
 	ncpsession.h \
 	ncpstatuscallback.h \
+	optional.h \
 	pathutils.h \
 	plpdirent.h \
 	plpintl.h \

--- a/lib/deviceendpoint.cc
+++ b/lib/deviceendpoint.cc
@@ -47,6 +47,7 @@ std::unique_ptr<DeviceEndpoint> DeviceEndpoint::connect(const std::string host,
     Enum<RFSV::errs> result;
     auto deviceConfiguration = device::read_configuration(*rfsv, result);
     std::string id = deviceConfiguration ? deviceConfiguration->id() : uuid::uuid4();
+    Optional<std::string> name = deviceConfiguration ? deviceConfiguration->name() : Optional<std::string>();
     bool hasPersistentConfiguration = static_cast<bool>(deviceConfiguration);
 
     auto rpcs = std::unique_ptr<RPCS>(RPCS::connect(host, port, &internalError));
@@ -66,10 +67,16 @@ std::unique_ptr<DeviceEndpoint> DeviceEndpoint::connect(const std::string host,
     }
 
     return std::unique_ptr<DeviceEndpoint>(
-        new DeviceEndpoint(id, hasPersistentConfiguration, std::move(rfsv), std::move(rpcs), std::move(clip)));
+        new DeviceEndpoint(id,
+                           name,
+                           hasPersistentConfiguration,
+                           std::move(rfsv),
+                           std::move(rpcs),
+                           std::move(clip)));
 }
 
 DeviceEndpoint::DeviceEndpoint(const std::string &id,
+                               const Optional<std::string> &name,
                                bool hasPersistentConfiguration,
                                std::unique_ptr<RFSV> rfsv,
                                std::unique_ptr<RPCS> rpcs,
@@ -78,7 +85,9 @@ DeviceEndpoint::DeviceEndpoint(const std::string &id,
 , rpcs_(std::move(rpcs))
 , clip_(std::move(clip))
 , id_(id)
-, hasPersistentConfiguration_(hasPersistentConfiguration) {}
+, name_(name)
+, hasPersistentConfiguration_(hasPersistentConfiguration) {
+}
 
 std::string DeviceEndpoint::id() const {
     return id_;
@@ -88,36 +97,15 @@ bool DeviceEndpoint::hasPersistentId() const {
     return hasPersistentConfiguration_;
 }
 
-Enum<RFSV::errs> DeviceEndpoint::getName(std::string &name) const {
-
-    // Don't bother to fetch the configuration if we know it does't exist.
-    if (!hasPersistentConfiguration_) {
-        return RFSV::E_PSI_FILE_RECORD;
-    }
-
-    // Read the configuration.
-    Enum<RFSV::errs> error = RFSV::E_PSI_GEN_NONE;
-    auto deviceConfiguration = device::read_configuration(*rfsv_, error);
-
-    // Check for E_PSI_FILE_NXIST and return it as E_PSI_FILE_RECORD which seems more logical.
-    if (error == RFSV::E_PSI_FILE_NXIST) {
-        return RFSV::E_PSI_FILE_RECORD;
-    }
-
-    // Return any errors.
-    if (error != RFSV::E_PSI_GEN_NONE) {
-        return error;
-    }
-
-    // Update the name and indicate success.
-    name = deviceConfiguration->name();
-    return RFSV::E_PSI_GEN_NONE;
+Optional<std::string> DeviceEndpoint::name() const {
+    return name_;
 }
 
 Enum<RFSV::errs> DeviceEndpoint::setName(const std::string &name) {
     auto deviceConfiguration = std::make_unique<DeviceConfiguration>(id_, name);
     auto result = device::write_configuration(*rfsv_, *deviceConfiguration);
     if (result == RFSV::E_PSI_GEN_NONE) {
+        name_ = name;
         hasPersistentConfiguration_ = true;
     }
     return result;

--- a/lib/deviceendpoint.h
+++ b/lib/deviceendpoint.h
@@ -27,6 +27,7 @@
 #include "connectionerror.h"
 #include "Enum.h"
 #include "device.h"
+#include "optional.h"
 
 class rclip;
 class RFSV;
@@ -51,15 +52,11 @@ public:
     bool hasPersistentId() const;
 
     /**
-    * Get the device name.
+    * Device name.
     *
-    * @param name Out-param for the device name.
-    *
-    * A return value of @ref RFSV::E_PSI_FILE_RECORD indicates that the device name has not been set.
-    *
-    * @result @ref RFSV::E_PSI_GEN_NONE on success; error otherwise.
+    * @return @ref Optional containing device name if set; empty otherwise.
     */
-    Enum<RFSV::errs> getName(std::string &name) const;
+    Optional<std::string> name() const;
 
     /**
     * Set the device name.
@@ -77,11 +74,13 @@ public:
 private:
 
     DeviceEndpoint(const std::string &id,
+                   const Optional<std::string> &name,
                    bool hasPersistentConfiguration,
                    std::unique_ptr<RFSV> rfsv,
                    std::unique_ptr<RPCS> rpcs,
                    std::unique_ptr<rclip> clip);
 
     const std::string id_;
+    Optional<std::string> name_;
     bool hasPersistentConfiguration_;
 };

--- a/lib/deviceendpoint.h
+++ b/lib/deviceendpoint.h
@@ -54,6 +54,9 @@ public:
     /**
     * Device name.
     *
+    * This value is read in @ref DeviceEndpoint::connect and cached in-memory during the lifetime
+    * of the @ref DeviceEndpoint instance.
+    *
     * @return @ref Optional containing device name if set; empty otherwise.
     */
     Optional<std::string> name() const;

--- a/lib/optional.h
+++ b/lib/optional.h
@@ -1,0 +1,172 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *  Copyright (c) 2026 Tom Sutcliffe
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "config.h"
+
+#include <cassert>
+#include <utility>
+
+
+template<typename T>
+class Optional {
+public:
+
+    Optional()
+    : hasValue_(false) {}
+
+    Optional(const T& value)
+    : hasValue_(true) {
+        *ptr() = value;
+    }
+
+    Optional(T&& value)
+    : hasValue_(true) {
+        *ptr() = std::move(value);
+    }
+
+    ~Optional() {
+        reset();
+    }
+
+    Optional(const Optional& other)
+    : hasValue_(other.hasValue_) {
+        if (!hasValue_) {
+            return;
+        }
+        new(ptr()) T(*other.ptr());
+
+    }
+
+    Optional(Optional&& other)
+    : hasValue_(other.hasValue_) {
+        if (!hasValue_) {
+            return;
+        }
+        new(ptr()) T(std::move(*other.ptr()));
+        other.hasValue_ = false;
+    }
+
+    Optional& operator=(const Optional& other) {
+
+        reset();
+
+        if (!other.hasValue_) {
+            return *this;
+        }
+        
+        new(ptr()) T(*other.ptr());
+        hasValue_ = true;
+        
+        return *this;
+    }
+
+    Optional& operator=(Optional&& other) noexcept {
+
+        reset();
+
+        if (!other.hasValue_) {
+            return *this;
+        }
+
+        new(ptr()) T(std::move(*other.ptr()));
+        hasValue_ = true;
+        other.hasValue_ = false;
+        
+        return *this;
+    }
+
+    Optional& operator=(const T& value) {
+
+        reset();
+
+        new(ptr()) T(value);
+        hasValue_ = true;
+
+        return *this;
+    }
+
+    Optional& operator=(const T&& value) {
+
+        reset();
+
+        new(ptr()) T(std::move(value));
+        hasValue_ = true;
+
+        return *this;
+    }
+
+    T& value() {
+        assert(hasValue_);
+        return *ptr();
+    }
+
+    const T& value() const {
+        assert(hasValue_);
+        return *ptr();
+    }
+
+    bool hasValue() const {
+        return hasValue_;
+    }
+
+    void reset() {
+        if (hasValue_) {
+            ptr()->~T();
+            hasValue_ = false;
+        }
+    }
+
+    T& operator*() {
+        return value();
+    }
+
+    const T& operator*() const {
+        return value();
+    }
+
+    T* operator->() {
+        return &value();
+    }
+
+    const T* operator->() const {
+        return &value();
+    }
+
+    explicit operator bool() const {
+        return hasValue_;
+    }
+    
+private:
+
+    T *ptr() {
+        return reinterpret_cast<T*>(value_);
+    }
+
+    const T *ptr() const {
+        return reinterpret_cast<const T*>(value_);
+    }
+    
+    alignas(T) unsigned char value_[sizeof(T)];
+
+    bool hasValue_;
+
+};

--- a/lib/optional.h
+++ b/lib/optional.h
@@ -35,12 +35,12 @@ public:
 
     Optional(const T& value)
     : hasValue_(true) {
-        *ptr() = value;
+        new(ptr()) T(value);
     }
 
     Optional(T&& value)
     : hasValue_(true) {
-        *ptr() = std::move(value);
+        new(ptr()) T(std::move(value));
     }
 
     ~Optional() {

--- a/plpftp/ftp.cc
+++ b/plpftp/ftp.cc
@@ -555,18 +555,17 @@ int FTP::session(DeviceEndpoint &deviceEndpoint, RFSV &rfsv, RPCS &rpcs, rclip &
     }
 
     {
-        std::string name;
-        auto nameError = deviceEndpoint.getName(name);
+        auto name = deviceEndpoint.name();
 
         Enum<RPCS::machs> machType;
         rpcs.getMachineType(machType);
         if (!once) {
             int speed = rfsv.getSpeed();
-            if (nameError != RFSV::E_PSI_GEN_NONE) {
-                cout << _("Connected to a ") << machType << _(", at ") << speed << _(" baud.") << endl;
-            } else {
-                cout << _("Connected to '") << name << _("', a ") << machType << _(", at ")
+            if (name) {
+                cout << _("Connected to '") << *name << _("', a ") << machType << _(", at ")
                      << speed << _(" baud.") << endl;
+            } else {
+                cout << _("Connected to a ") << machType << _(", at ") << speed << _(" baud.") << endl;
             }
             cout << endl;
         }
@@ -742,14 +741,11 @@ int FTP::session(DeviceEndpoint &deviceEndpoint, RFSV &rfsv, RPCS &rpcs, rclip &
             continue;
         }
         if (!strcmp(argv[0], "devicename") && (argc == 1)) {
-            std::string name;
-            auto error = deviceEndpoint.getName(name);
-            if (error == RFSV::E_PSI_GEN_NONE) {
-                cout << name << endl;
-            } else if (error == RFSV::E_PSI_FILE_RECORD) {
-                cout << _("Error: ") << "not set; use setdevicename to set a name and persist the device id" << endl;
+            auto name = deviceEndpoint.name();
+            if (name) {
+                cout << *name << endl;
             } else {
-                cerr << _("Error: ") << error << endl;
+                cout << _("Error: ") << "not set; use setdevicename to set a name and persist the device id" << endl;
             }
             continue;
         }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,6 +29,7 @@ tests_SOURCES = \
     drivetests.cc \
     initests.cc \
     main.cc \
+    optionaltests.cc \
     pathutilstests.cc \
     plpdirenttests.cc
 

--- a/tests/optionaltests.cc
+++ b/tests/optionaltests.cc
@@ -19,6 +19,7 @@
  */
 #include "config.h"
 
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>

--- a/tests/optionaltests.cc
+++ b/tests/optionaltests.cc
@@ -19,8 +19,9 @@
  */
 #include "config.h"
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string>
 
 #include "doctest.h"
 #include "optional.h"

--- a/tests/optionaltests.cc
+++ b/tests/optionaltests.cc
@@ -1,0 +1,86 @@
+/*
+ * This file is part of plptools.
+ *
+ *  Copyright (c) 2026 Jason Morley <hello@jbmorley.co.uk>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "config.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "doctest.h"
+#include "optional.h"
+
+class Dummy {
+public:
+    Dummy(std::string value)
+    : value_(value) {};
+
+    std::string value() {
+        return value_;
+    }
+
+private:
+    std::string value_;
+};
+
+TEST_CASE("pathutils::epoc_basename") {
+    std::string hello = "hello";
+    auto foo = Optional<std::string>(hello);
+    CHECK(foo.hasValue());
+
+    Optional<std::string> bar("Hello, World");
+    CHECK(bar.value() == "Hello, World");
+
+    
+    auto c = Optional<std::string>();
+    auto d = Optional<uint8_t>(12);
+
+    Optional<std::string> e;
+    Optional<std::string> f{};
+    Optional<uint8_t> g(8);
+    Optional<uint8_t> h;
+
+    Optional<std::string> hey;
+    CHECK(!hey.hasValue());
+
+    auto moveFrom = std::make_unique<std::string>("Hello");
+    hey = std::move(*moveFrom);
+
+
+    auto z = Optional<std::string>("Randodm!");
+    hey = z;
+    hey = Optional<std::string>("Bob");
+
+    hey = Optional<std::string>("cheese it!");
+
+    c = bar;
+
+    auto optionalDummy = Optional<Dummy>(Dummy("cheese"));
+    CHECK(optionalDummy->value() == "cheese");
+    CHECK(optionalDummy.hasValue());
+
+
+    SUBCASE("regular constructor") {
+        Optional<std::string> a("Hello, World!");
+        CHECK(*a == "Hello, World!");
+        auto b = Optional<std::string>(a);
+        CHECK(*b == "Hello, World!");
+    }
+
+    // TODO: Regular constructor?
+}

--- a/tests/optionaltests.cc
+++ b/tests/optionaltests.cc
@@ -19,6 +19,7 @@
  */
 #include "config.h"
 
+#include <cstdint>
 #include <memory>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This change caches the device name (from the device configuration) in `DeviceEndpoint`. It introduces a new `Optional` class (we can't use `std::optional` because we're targeting C++11) to allow us to represent the unset state (before a device configuration has been written to disk).